### PR TITLE
Refactoring/extract contract tests

### DIFF
--- a/build-logic/src/main/kotlin/ff4k.publish.gradle.kts
+++ b/build-logic/src/main/kotlin/ff4k.publish.gradle.kts
@@ -13,6 +13,7 @@ plugins.withId("org.jetbrains.kotlin.multiplatform") {
         jvm {
             withSourcesJar()
         }
+
         linuxX64 {
             withSourcesJar()
         }

--- a/ff4k-contract-test/README.md
+++ b/ff4k-contract-test/README.md
@@ -1,0 +1,98 @@
+# FF4K Contract Test Module
+
+The `ff4k-contract-test` module provides reusable contract tests for verifying
+implementations of extensible FF4K functionality. This module serves as a
+comprehensive test suite that ensures consistency and correctness across both
+internal modules and external extensions.
+
+## Purpose
+
+This module exists to:
+
+- **Ensure Consistency**: All implementations of FF4K interfaces follow the same behavioral contracts
+- **Enable Extensibility**: Both internal modules and external developers can verify their implementations using standardized test suites
+- **Reduce Duplication**: Eliminates the need to write repetitive tests for common functionality
+- **Maintain Quality**: Provides comprehensive test coverage that all implementations must pass
+- **Support Multiple Platforms**: Built with Kotlin Multiplatform to work across JVM, Android, and Native targets
+
+## Who Should Use This Module
+
+### Internal Module Development
+When developing new modules within the FF4K project that implement core
+interfaces, use the contract tests to ensure your implementation meets the
+required standards.
+
+### External Library Extensions
+When extending FF4K with custom implementations (e.g., custom property types,
+storage backends, or feature flags), use these contract tests to verify your
+implementation is correct and compatible with the FF4K ecosystem.
+
+## Available Contract Tests
+
+### PropertyContractTest
+
+Tests for implementations of the `Property<V>` interface. See the [source code](src/commonMain/kotlin/com/yonatankarp/ff4k/test/contract/property/PropertyContractTest.kt)
+for the complete test contract.
+
+_More contract tests will be added as the library grows._
+
+## Usage
+
+### Add the Dependency
+
+**Gradle (Kotlin DSL)**
+```kotlin
+dependencies {
+    testImplementation("com.yonatankarp:ff4k-contract-test:<version>")
+}
+```
+
+**Gradle (Groovy DSL)**
+```groovy
+dependencies {
+    testImplementation 'com.yonatankarp:ff4k-contract-test:<version>'
+}
+```
+
+**Maven**
+```xml
+<dependency>
+    <groupId>com.yonatankarp</groupId>
+    <artifactId>ff4k-contract-test</artifactId>
+    <version>${ff4k.version}</version>
+    <scope>test</scope>
+</dependency>
+```
+
+### Implement Your Tests
+
+Extend the appropriate contract test class and implement the required abstract methods. The contract tests will automatically verify that your implementation meets FF4K standards.
+
+For detailed examples, see how FF4K core uses these tests:
+
+- **Property implementations**: See `ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/property/`
+  - `PropertyStringTest.kt`
+  - `PropertyIntTest.kt`
+  - `PropertyBooleanTest.kt`
+  - `PropertyBigDecimalTest.kt`
+  - And more...
+
+These examples demonstrate how to extend the contract tests for your own implementations.
+
+## Multiplatform Support
+
+This module is built with Kotlin Multiplatform and supports:
+- JVM
+- Android
+- iOS
+- Native (Linux, Windows, macOS)
+
+The contract tests work consistently across all supported platforms.
+
+## Contributing New Contract Tests
+
+When adding new extensible functionality to FF4K, consider adding contract tests to this module to ensure consistent behavior across implementations.
+
+## License
+
+This module is part of FF4K and is licensed under the same license as the parent project.

--- a/ff4k-contract-test/build.gradle.kts
+++ b/ff4k-contract-test/build.gradle.kts
@@ -1,0 +1,28 @@
+plugins {
+    id("ff4k.multiplatform")
+    id("ff4k.publish")
+    id("ff4k.coverage")
+    id("ff4k.documentation")
+    alias(libs.plugins.kotlin.serialization)
+}
+
+kotlin {
+    sourceSets {
+        commonMain.dependencies {
+            api(project(":ff4k-core"))
+            api(libs.kotlinx.serialization.json)
+            api(libs.bundles.bignum)
+            api(libs.kotlin.test)
+        }
+
+        jvmMain.dependencies {
+            implementation(libs.kotlin.test.junit)
+        }
+
+        androidMain {
+            dependencies {
+                implementation(libs.kotlin.test.junit)
+            }
+        }
+    }
+}

--- a/ff4k-contract-test/src/commonMain/kotlin/com/yonatankarp/ff4k/test/contract/property/PropertyContractTest.kt
+++ b/ff4k-contract-test/src/commonMain/kotlin/com/yonatankarp/ff4k/test/contract/property/PropertyContractTest.kt
@@ -1,6 +1,7 @@
-package com.yonatankarp.ff4k.property
+package com.yonatankarp.ff4k.test.contract.property
 
 import com.ionspin.kotlin.bignum.serialization.kotlinx.humanReadableSerializerModule
+import com.yonatankarp.ff4k.property.Property
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.json.Json
 import kotlin.test.Test

--- a/ff4k-core/build.gradle.kts
+++ b/ff4k-core/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     id("ff4k.documentation")
     alias(libs.plugins.kotlin.serialization)
 }
-//
+
 kotlin {
     sourceSets {
         commonMain.dependencies {
@@ -19,11 +19,12 @@ kotlin {
         }
 
         commonTest.dependencies {
+            implementation(project(":ff4k-contract-test"))
             implementation(libs.kotlinx.coroutines.test)
         }
     }
 }
 
-// dependencies {
-//    add("androidUnitTestImplementation", libs.robolectric)
-// }
+dependencies {
+    add("androidUnitTestImplementation", libs.robolectric)
+}

--- a/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/property/PropertyBigDecimalTest.kt
+++ b/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/property/PropertyBigDecimalTest.kt
@@ -3,6 +3,7 @@ package com.yonatankarp.ff4k.property
 import com.ionspin.kotlin.bignum.decimal.BigDecimal
 import com.ionspin.kotlin.bignum.decimal.toBigDecimal
 import com.ionspin.kotlin.bignum.serialization.kotlinx.humanReadableSerializerModule
+import com.yonatankarp.ff4k.test.contract.property.PropertyContractTest
 import kotlinx.serialization.json.Json
 import kotlin.test.assertTrue
 

--- a/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/property/PropertyBigIntegerTest.kt
+++ b/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/property/PropertyBigIntegerTest.kt
@@ -3,6 +3,7 @@ package com.yonatankarp.ff4k.property
 import com.ionspin.kotlin.bignum.integer.BigInteger
 import com.ionspin.kotlin.bignum.integer.toBigInteger
 import com.ionspin.kotlin.bignum.serialization.kotlinx.humanReadableSerializerModule
+import com.yonatankarp.ff4k.test.contract.property.PropertyContractTest
 import kotlinx.serialization.json.Json
 import kotlin.test.assertTrue
 

--- a/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/property/PropertyBooleanTest.kt
+++ b/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/property/PropertyBooleanTest.kt
@@ -1,5 +1,6 @@
 package com.yonatankarp.ff4k.property
 
+import com.yonatankarp.ff4k.test.contract.property.PropertyContractTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 

--- a/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/property/PropertyByteTest.kt
+++ b/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/property/PropertyByteTest.kt
@@ -1,5 +1,7 @@
 package com.yonatankarp.ff4k.property
 
+import com.yonatankarp.ff4k.test.contract.property.PropertyContractTest
+
 /**
  * Tests for PropertyByte class.
  *

--- a/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/property/PropertyDoubleTest.kt
+++ b/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/property/PropertyDoubleTest.kt
@@ -1,5 +1,7 @@
 package com.yonatankarp.ff4k.property
 
+import com.yonatankarp.ff4k.test.contract.property.PropertyContractTest
+
 /**
  * Tests for PropertyDouble class.
  *

--- a/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/property/PropertyFloatTest.kt
+++ b/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/property/PropertyFloatTest.kt
@@ -1,5 +1,7 @@
 package com.yonatankarp.ff4k.property
 
+import com.yonatankarp.ff4k.test.contract.property.PropertyContractTest
+
 /**
  * Tests for PropertyFloat class.
  *

--- a/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/property/PropertyInstantTest.kt
+++ b/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/property/PropertyInstantTest.kt
@@ -1,5 +1,6 @@
 package com.yonatankarp.ff4k.property
 
+import com.yonatankarp.ff4k.test.contract.property.PropertyContractTest
 import kotlinx.datetime.Instant
 import kotlin.test.assertTrue
 

--- a/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/property/PropertyIntTest.kt
+++ b/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/property/PropertyIntTest.kt
@@ -1,5 +1,7 @@
 package com.yonatankarp.ff4k.property
 
+import com.yonatankarp.ff4k.test.contract.property.PropertyContractTest
+
 /**
  * Tests for PropertyInt class.
  *

--- a/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/property/PropertyLocalDateTest.kt
+++ b/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/property/PropertyLocalDateTest.kt
@@ -1,5 +1,6 @@
 package com.yonatankarp.ff4k.property
 
+import com.yonatankarp.ff4k.test.contract.property.PropertyContractTest
 import kotlinx.datetime.LocalDate
 import kotlin.test.assertTrue
 

--- a/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/property/PropertyLocalDateTimeTest.kt
+++ b/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/property/PropertyLocalDateTimeTest.kt
@@ -1,5 +1,6 @@
 package com.yonatankarp.ff4k.property
 
+import com.yonatankarp.ff4k.test.contract.property.PropertyContractTest
 import kotlinx.datetime.LocalDateTime
 import kotlin.test.assertTrue
 

--- a/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/property/PropertyLogLevelTest.kt
+++ b/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/property/PropertyLogLevelTest.kt
@@ -1,6 +1,7 @@
 package com.yonatankarp.ff4k.property
 
 import com.yonatankarp.ff4k.property.PropertyLogLevel.LogLevel
+import com.yonatankarp.ff4k.test.contract.property.PropertyContractTest
 import kotlin.test.assertTrue
 
 /**

--- a/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/property/PropertyLongTest.kt
+++ b/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/property/PropertyLongTest.kt
@@ -1,5 +1,7 @@
 package com.yonatankarp.ff4k.property
 
+import com.yonatankarp.ff4k.test.contract.property.PropertyContractTest
+
 /**
  * Tests for PropertyLong class.
  *

--- a/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/property/PropertyShortTest.kt
+++ b/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/property/PropertyShortTest.kt
@@ -1,5 +1,7 @@
 package com.yonatankarp.ff4k.property
 
+import com.yonatankarp.ff4k.test.contract.property.PropertyContractTest
+
 /**
  * Tests for PropertyShort class.
  *

--- a/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/property/PropertyStringTest.kt
+++ b/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/property/PropertyStringTest.kt
@@ -1,5 +1,6 @@
 package com.yonatankarp.ff4k.property
 
+import com.yonatankarp.ff4k.test.contract.property.PropertyContractTest
 import kotlin.test.assertTrue
 
 /**

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,7 +20,7 @@ kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-t
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "serialization" }
 kotlinx-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version.ref = "kmp-datetime" }
 bignum = { module = "com.ionspin.kotlin:bignum", version.ref = "bignum" }
-bignum-serialization = { module = "com.ionspin.kotlin:bignum-serialization-kotlinx", version.ref = "bignum"}
+bignum-serialization = { module = "com.ionspin.kotlin:bignum-serialization-kotlinx", version.ref = "bignum" }
 
 # Ktor (Web & Networking)
 ktor-server-core = { module = "io.ktor:ktor-server-core", version.ref = "ktor" }
@@ -35,6 +35,7 @@ dokka-gradle-plugin = { module = "org.jetbrains.dokka:dokka-gradle-plugin", vers
 
 # Testing
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
+kotlin-test-junit = { module = "org.jetbrains.kotlin:kotlin-test-junit", version.ref = "kotlin" }
 robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectric" }
 
 # JVM Platform-Specific

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -18,4 +18,5 @@ rootProject.name = "ff4k"
 
 include(
     "ff4k-core",
+    "ff4k-contract-test",
 )

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -9,7 +9,7 @@ sonar.inclusions=**/src/**Main/**/*.kt
 sonar.test.inclusions=**/src/**Test/**/*.kt
 
 # Exclude test modules, build directories, and generated code
-sonar.exclusions=**/build/**,**/ff4k-test/**,**/build-logic/**
+sonar.exclusions=**/build/**,**/ff4k-*-test/**,**/build-logic/**
 
 # Exclude function naming convention rule for test files
 sonar.issue.ignore.multicriteria=e1,e2


### PR DESCRIPTION
This change extracts the contract tests to its own module, so they can be used in the `ff4k-core` module, and any other module in the future that will implement the core functionality (both by the project or by users who wish to extend the functionality)

Closes #82 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a new contract-test module and integrated it into the build
  * Expanded multiplatform publishing to include Linux x64
  * Enabled Android and JVM unit testing with JUnit and added the Kotlin test JUnit dependency
  * Broadened SonarQube exclusion patterns

* **Documentation**
  * Added README for the contract-test module detailing usage and contribution guidance

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->