### PR TITLE
fix: Enable serialization for Feature and FlippingStrategy objects

### DIFF
--- a/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/serialization/FF4kSerializersModule.kt
+++ b/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/serialization/FF4kSerializersModule.kt
@@ -1,0 +1,45 @@
+package com.yonatankarp.ff4k.serialization
+
+import com.ionspin.kotlin.bignum.serialization.kotlinx.humanReadableSerializerModule
+import com.yonatankarp.ff4k.core.FlippingStrategy
+import com.yonatankarp.ff4k.property.Property
+import com.yonatankarp.ff4k.property.PropertyBigDecimal
+import com.yonatankarp.ff4k.property.PropertyBigInteger
+import com.yonatankarp.ff4k.property.PropertyBoolean
+import com.yonatankarp.ff4k.property.PropertyByte
+import com.yonatankarp.ff4k.property.PropertyDouble
+import com.yonatankarp.ff4k.property.PropertyFloat
+import com.yonatankarp.ff4k.property.PropertyInstant
+import com.yonatankarp.ff4k.property.PropertyInt
+import com.yonatankarp.ff4k.property.PropertyLocalDate
+import com.yonatankarp.ff4k.property.PropertyLocalDateTime
+import com.yonatankarp.ff4k.property.PropertyLogLevel
+import com.yonatankarp.ff4k.property.PropertyLong
+import com.yonatankarp.ff4k.property.PropertyShort
+import com.yonatankarp.ff4k.property.PropertyString
+import kotlinx.serialization.modules.SerializersModule
+import kotlinx.serialization.modules.plus
+import kotlinx.serialization.modules.polymorphic
+
+val ff4kSerializersModule = SerializersModule {
+    polymorphic(Property::class) {
+        subclass(PropertyInt::class, PropertyInt.serializer())
+        subclass(PropertyString::class, PropertyString.serializer())
+        subclass(PropertyDouble::class, PropertyDouble.serializer())
+        subclass(PropertyFloat::class, PropertyFloat.serializer())
+        subclass(PropertyLong::class, PropertyLong.serializer())
+        subclass(PropertyBoolean::class, PropertyBoolean.serializer())
+        subclass(PropertyLocalDateTime::class, PropertyLocalDateTime.serializer())
+        subclass(PropertyLogLevel::class, PropertyLogLevel.serializer())
+        subclass(PropertyBigInteger::class, PropertyBigInteger.serializer())
+        subclass(PropertyBigDecimal::class, PropertyBigDecimal.serializer())
+        subclass(PropertyLocalDate::class, PropertyLocalDate.serializer())
+        subclass(PropertyInstant::class, PropertyInstant.serializer())
+        subclass(PropertyShort::class, PropertyShort.serializer())
+        subclass(PropertyByte::class, PropertyByte.serializer())
+    }
+
+    polymorphic(FlippingStrategy::class) {
+        // Register FlippingStrategy implementations here as they are created
+    }
+} + humanReadableSerializerModule


### PR DESCRIPTION
Fix serialization issues preventing Feature and FlippingStrategy objects from being correctly marshaled to and from JSON. This ensures polymorphic property types and strategy configurations are handled correctly during storage and API interactions.

Update the flipping strategy contract to enforce serialization compatibility for all future strategy implementations.

Closes #83

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added polymorphic JSON serialization support for features, properties and strategies via a shared serializers module.

* **Tests**
  * Added serialization/deserialization tests validating feature payloads, property types/values, and strategy JSON round-trips.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->