### PR TITLE
refactor: Remove @inheritDoc

### DIFF
--- a/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/property/multi/AbstractPropertyMap.kt
+++ b/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/property/multi/AbstractPropertyMap.kt
@@ -28,51 +28,39 @@ abstract class AbstractPropertyMap<T, M : MutableMap<String, out T>>(
         }
     }
 
-    /** {@inheritDoc} */
     override val size: Int
         get() = value.size
 
-    /** {@inheritDoc} */
     override fun isEmpty(): Boolean = value.isEmpty()
 
-    /** {@inheritDoc} */
     override fun containsKey(key: String): Boolean = key in value
 
-    /** {@inheritDoc} */
     override fun containsValue(value: T): Boolean = value in this.value.values
 
-    /** {@inheritDoc} */
     override operator fun get(key: String): T? = value[key]
 
-    /** {@inheritDoc} */
     override fun remove(key: String): T? = value.remove(key)
 
     operator fun minusAssign(key: String) {
         remove(key)
     }
 
-    /** {@inheritDoc} */
     override fun clear() = value.clear()
 
-    /** {@inheritDoc} */
     override val keys: MutableSet<String>
         get() = value.keys
 
-    /** {@inheritDoc} */
     @Suppress("UNCHECKED_CAST")
     override val entries: Entries<T>
         get() = value.entries as Entries<T>
 
-    /** {@inheritDoc} */
     @Suppress("UNCHECKED_CAST")
     override val values: Values<T>
         get() = value.values as Values<T>
 
-    /** {@inheritDoc} */
     @Suppress("UNCHECKED_CAST")
     override fun put(key: String, value: T): T? = (this.value as MutableMap<String, T>).put(key, value)
 
-    /** {@inheritDoc} */
     @Suppress("UNCHECKED_CAST")
     override fun putAll(from: Map<out String, T>) {
         (value as MutableMap<String, T>).putAll(from)

--- a/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/property/multi/AbstractPropertyMultiValued.kt
+++ b/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/property/multi/AbstractPropertyMultiValued.kt
@@ -25,7 +25,6 @@ abstract class AbstractPropertyMultiValued<T, C : MutableCollection<T>>(
         }
     }
 
-    /** {@inheritDoc} */
     override val size: Int get() = value.size
 
     /**
@@ -35,7 +34,6 @@ abstract class AbstractPropertyMultiValued<T, C : MutableCollection<T>>(
      */
     override fun add(element: T): Boolean = value.add(element)
 
-    /** {@inheritDoc} */
     override fun addAll(elements: Collection<T>): Boolean = value.addAll(elements)
 
     /**
@@ -47,19 +45,14 @@ abstract class AbstractPropertyMultiValued<T, C : MutableCollection<T>>(
         addAll(values.toList())
     }
 
-    /** {@inheritDoc} */
     override fun isEmpty(): Boolean = value.isEmpty()
 
-    /** {@inheritDoc} */
     override fun contains(element: T): Boolean = element in value
 
-    /** {@inheritDoc} */
     override fun containsAll(elements: Collection<T>): Boolean = value.containsAll(elements)
 
-    /** {@inheritDoc} */
     override fun remove(element: T): Boolean = value.remove(element)
 
-    /** {@inheritDoc} */
     override fun removeAll(elements: Collection<T>): Boolean = value.removeAll(elements.toSet())
 
     operator fun minusAssign(element: T) {
@@ -70,13 +63,10 @@ abstract class AbstractPropertyMultiValued<T, C : MutableCollection<T>>(
         add(element)
     }
 
-    /** {@inheritDoc} */
     override fun retainAll(elements: Collection<T>): Boolean = value.retainAll(elements.toSet())
 
-    /** {@inheritDoc} */
     override fun iterator(): MutableIterator<T> = value.iterator()
 
-    /** {@inheritDoc}  */
     override fun clear() {
         value.clear()
     }


### PR DESCRIPTION
This change removes the `/* {@inheritDoc} */` as it's a Java-style documentation and not supported by Dokka. In dokka, if the property does not have any documentation, the parent's documentation is inherited, while having the `/* {@inheritDoc} */` this text will appear instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal code maintenance updates with no impact to user-facing functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->