### PR TITLE
Refactor FeatureStore to use internal suspend functions

### DIFF
--- a/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/store/InMemoryFeatureStore.kt
+++ b/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/store/InMemoryFeatureStore.kt
@@ -1,10 +1,8 @@
 package com.yonatankarp.ff4k.store
 
 import com.yonatankarp.ff4k.core.Feature
-import com.yonatankarp.ff4k.exception.FeatureAlreadyExistsException
-import com.yonatankarp.ff4k.exception.FeatureNotFoundException
+import com.yonatankarp.ff4k.utils.withReentrantLock
 import kotlinx.coroutines.sync.Mutex
-import kotlinx.coroutines.sync.withLock
 
 /**
  * In-memory implementation of [AbstractFeatureStore] that stores features in memory.
@@ -12,8 +10,8 @@ import kotlinx.coroutines.sync.withLock
  * This implementation provides thread-safe operations using a [Mutex] to protect concurrent access.
  * All data is stored in memory and will be lost when the application stops.
  *
- * **Thread Safety**: All operations are protected by a non-reentrant mutex to ensure thread safety.
- * Do not call suspend methods from within locked blocks to avoid deadlocks.
+ * **Thread Safety**: All operations are protected by a reentrant mutex mechanism to ensure thread safety.
+ * Internal suspend methods can be safely called from within locked blocks.
  *
  * **Use Cases**:
  * - Testing and development
@@ -30,87 +28,54 @@ class InMemoryFeatureStore(
     private val features: MutableMap<String, Feature> = initialFeatures.toMutableMap()
     private val mutex: Mutex = Mutex()
 
-    override suspend fun contains(featureId: String): Boolean = mutex.withLock {
+    override suspend fun contains(featureId: String): Boolean = mutex.withReentrantLock {
         featureId in features
     }
 
-    override suspend fun plusAssign(feature: Feature) = mutex.withLock {
+    override suspend fun plusAssign(feature: Feature) = mutex.withReentrantLock {
         requireFeatureNotExist(feature.uid)
         features[feature.uid] = feature
     }
 
-    override suspend fun minusAssign(featureId: String): Unit = mutex.withLock {
+    override suspend fun minusAssign(featureId: String): Unit = mutex.withReentrantLock {
         requireFeatureExist(featureId)
         features.remove(featureId)
     }
 
-    override suspend fun update(feature: Feature): Unit = mutex.withLock {
+    override suspend fun update(feature: Feature): Unit = mutex.withReentrantLock {
         requireFeatureExist(feature.uid)
         features[feature.uid] = feature
     }
 
-    override suspend fun get(featureId: String): Feature? = mutex.withLock {
+    override suspend fun get(featureId: String): Feature? = mutex.withReentrantLock {
         features[featureId]
     }
 
-    override suspend fun getAll(): Map<String, Feature> = mutex.withLock {
+    override suspend fun getAll(): Map<String, Feature> = mutex.withReentrantLock {
         features.toMap()
     }
 
-    override suspend fun clear(): Unit = mutex.withLock {
+    override suspend fun clear(): Unit = mutex.withReentrantLock {
         features.clear()
     }
 
-    override suspend fun isEmpty(): Boolean = mutex.withLock {
+    override suspend fun isEmpty(): Boolean = mutex.withReentrantLock {
         features.isEmpty()
     }
 
-    override suspend fun count(): Int = mutex.withLock { features.size }
+    override suspend fun count(): Int = mutex.withReentrantLock { features.size }
 
     override suspend fun updateFeature(
         featureId: String,
         transform: (Feature) -> Feature,
-    ): Unit = mutex.withLock {
-        val feature = features[featureId]
-            ?: throw FeatureNotFoundException("Feature with id $featureId not found.")
+    ): Unit = mutex.withReentrantLock {
+        val feature = getOrThrow(featureId)
         val transformed = transform(feature)
         check(transformed.uid == featureId) { "Cannot change feature uid during update. Expected: $featureId, got: ${transformed.uid}" }
-        features[featureId] = transformed
+        update(transformed)
     }
 
-    override suspend fun createOrUpdate(feature: Feature): Unit = mutex.withLock {
-        features[feature.uid] = feature
-    }
-
-    override suspend fun toggle(featureId: String): Unit = mutex.withLock {
-        val feature = features[featureId]
-            ?: throw FeatureNotFoundException("Feature with id $featureId not found.")
-        features[featureId] = feature.toggle()
-    }
-
-    override suspend fun getOrThrow(featureId: String): Feature = mutex.withLock {
-        features[featureId] ?: throw FeatureNotFoundException("Feature with id $featureId not found.")
-    }
-
-    /**
-     * Validates that a feature exists in the store.
-     * This method assumes the caller already holds the mutex lock.
-     */
-    private fun requireFeatureExist(featureId: String) {
-        require(featureId.isNotBlank()) { "featureId cannot be empty" }
-        if (featureId !in features) {
-            throw FeatureNotFoundException(featureId)
-        }
-    }
-
-    /**
-     * Validates that a feature does not exist in the store.
-     * This method assumes the caller already holds the mutex lock.
-     */
-    private fun requireFeatureNotExist(featureId: String) {
-        require(featureId.isNotBlank()) { "featureId cannot be empty" }
-        if (featureId in features) {
-            throw FeatureAlreadyExistsException(featureId)
-        }
+    override suspend fun createOrUpdate(feature: Feature): Unit = mutex.withReentrantLock {
+        super.createOrUpdate(feature)
     }
 }

--- a/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/utils/MutexExtensions.kt
+++ b/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/utils/MutexExtensions.kt
@@ -1,0 +1,45 @@
+package com.yonatankarp.ff4k.utils
+
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
+import kotlin.coroutines.CoroutineContext
+
+/**
+ * A reentrant lock implementation for Kotlin Coroutines Mutex.
+ *
+ * This function checks if the current coroutine context already holds the lock for this specific Mutex.
+ * If it does, it executes the block directly.
+ * If not, it acquires the lock, adds a marker to the context, and then executes the block.
+ *
+ * This implementation supports nesting different mutexes (e.g. locking A then B) because `withContext`
+ * restores the previous context value upon completion.
+ */
+suspend fun <T> Mutex.withReentrantLock(block: suspend () -> T): T {
+    val key = ReentrantMutexContextElement.Key
+    val element = currentCoroutineContext()[key]
+
+    return if (element != null && element.heldMutexes.any { it === this }) {
+        block()
+    } else {
+        withLock {
+            val currentHeld = element?.heldMutexes ?: emptyList()
+            val newHeld = currentHeld + this@withReentrantLock
+            withContext(ReentrantMutexContextElement(newHeld)) {
+                block()
+            }
+        }
+    }
+}
+
+/**
+ * Context element to track which Mutexes are currently held by the coroutine.
+ */
+internal class ReentrantMutexContextElement(
+    val heldMutexes: List<Mutex>,
+) : CoroutineContext.Element {
+    override val key: CoroutineContext.Key<*> = Key
+
+    companion object Key : CoroutineContext.Key<ReentrantMutexContextElement>
+}

--- a/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/utils/MutexExtensionsTest.kt
+++ b/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/utils/MutexExtensionsTest.kt
@@ -1,0 +1,120 @@
+package com.yonatankarp.ff4k.utils
+
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withTimeout
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class MutexExtensionsTest {
+
+    @Test
+    fun `should allow re-entry in the same coroutine`() = runTest {
+        // Given
+        val mutex = Mutex()
+
+        // When
+        mutex.withReentrantLock {
+            // Then
+            mutex.withReentrantLock {
+                assertTrue(true, "Should be able to re-enter lock")
+            }
+        }
+    }
+
+    @Test
+    fun `should guarantee mutual exclusion between coroutines`() = runTest {
+        withDefaultTimeout {
+            // Given
+            val mutex = Mutex()
+            var inCriticalSection = false
+            val job1AcquiredLock = CompletableDeferred<Unit>()
+            val releaseJob1 = CompletableDeferred<Unit>()
+
+            val job1 = launch {
+                mutex.withReentrantLock {
+                    inCriticalSection = true
+                    job1AcquiredLock.complete(Unit)
+                    releaseJob1.await()
+                    inCriticalSection = false
+                }
+            }
+
+            job1AcquiredLock.await()
+
+            // When
+            val job2 = launch {
+                mutex.withReentrantLock {
+                    assertFalse(inCriticalSection, "Job2 entered critical section while Job1 held the lock")
+                }
+            }
+
+            testScheduler.advanceTimeBy(100)
+
+            // Then
+            assertTrue(job2.isActive, "Job2 should be suspended waiting for the lock")
+            assertFalse(job2.isCompleted, "Job2 should not have completed yet")
+
+            // When
+            releaseJob1.complete(Unit)
+            job1.join()
+            job2.join()
+
+            // Then
+            assertTrue(job2.isCompleted, "Job2 should have completed after lock release")
+        }
+    }
+
+    @Test
+    fun `should support nested locking of different mutexes`() = runTest {
+        withDefaultTimeout {
+            // Given
+            val mutex1 = Mutex()
+            val mutex2 = Mutex()
+
+            // When
+            mutex1.withReentrantLock {
+                mutex2.withReentrantLock {
+                    // Then
+                    mutex1.withReentrantLock {
+                        assertTrue(true, "Should be able to re-enter mutex1 while holding mutex2")
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `should support interleaving locks`() = runTest {
+        withDefaultTimeout {
+            // Given
+            val mutex = Mutex()
+
+            launch {
+                mutex.withReentrantLock {
+                    // Lock held
+                }
+            }.join()
+
+            // When
+            mutex.withReentrantLock {
+                // Then
+                assertTrue(true, "Should be able to acquire lock after it was released")
+            }
+        }
+    }
+
+    private suspend fun <T> withDefaultTimeout(block: suspend CoroutineScope.() -> T): T = withTimeout(DEFAULT_TIMEOUT) {
+        block()
+    }
+
+    companion object {
+        private const val DEFAULT_TIMEOUT = 2_000L
+    }
+}


### PR DESCRIPTION
Updated AbstractFeatureStore to provide default implementations for createOrUpdate, toggle, and getOrThrow, leveraging the core suspend operators.

Refactored InMemoryFeatureStore to utilize these base implementations while maintaining thread safety through the newly adopted ReentrantMutexContextElement mechanism. This simplifies the implementation and removes code duplication while ensuring atomic operations.

Closes #92

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added create-or-update, toggle, and get-or-throw operations for feature management.
  * Added validation helpers to enforce presence/absence of features and surface clear errors.

* **Improvements**
  * Introduced reentrant locking for in-memory operations to avoid deadlocks when calling suspend helpers.
  * Centralized update flow to use shared validation and reduce direct state mutations.

* **Tests**
  * Added tests verifying reentrant lock behavior and concurrency safety.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->