### PR TITLE
docs: add coroutine context to examples and fix CI workflow

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -13,10 +13,10 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: 3.x
 
@@ -24,18 +24,18 @@ jobs:
         run: pip install mkdocs-material
 
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: '17'
 
       - name: Generate KDoc
-        run: ./gradlew dokkaHtmlMultiModule
+        run: ./gradlew dokkaGenerateHtml
 
       - name: Copy KDoc to docs
         run: |
           mkdir -p docs/api
-          cp -r build/dokka/htmlMultiModule/* docs/api/
+          cp -r build/dokka/html/* docs/api/
 
       - name: Build and Deploy MkDocs
         run: mkdocs gh-deploy --force

--- a/docs/extending.md
+++ b/docs/extending.md
@@ -12,6 +12,8 @@ To create a custom feature store, implement the `FeatureStore` interface. For co
 
 ```kotlin
 import com.yonatankarp.ff4k.core.Feature
+import com.yonatankarp.ff4k.exception.FeatureAlreadyExistsException
+import com.yonatankarp.ff4k.exception.FeatureNotFoundException
 import com.yonatankarp.ff4k.store.AbstractFeatureStore
 
 class MyCustomFeatureStore : AbstractFeatureStore() {
@@ -67,11 +69,11 @@ import com.yonatankarp.ff4k.core.PropertyStore
 import com.yonatankarp.ff4k.property.Property
 
 class MyCustomPropertyStore : PropertyStore {
-    // Implement methods: get, put, delete, etc.
+   // Implement interface...
 }
 ```
 
-## verifying Your Implementation
+## Verifying Your Implementation
 
 It is critical to ensure your custom store behaves correctly. FF4K provides a [Contract Test Suite](testing.md) that you can use to automatically verify your implementation against the expected behavior.
 
@@ -80,10 +82,12 @@ It is critical to ensure your custom store behaves correctly. FF4K provides a [C
 Once implemented, pass your custom store to the `ff4k` configuration function.
 
 ```kotlin
-val ff4k = ff4k(
-    featureStore = MyCustomFeatureStore(),
-    propertyStore = MyCustomPropertyStore()
-) {
-    // ...
+suspend fun main() {
+    val ff4k = ff4k(
+        featureStore = MyCustomFeatureStore(),
+        propertyStore = MyCustomPropertyStore()
+    ) {
+        // ...
+    }
 }
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,18 +25,20 @@ dependencies {
 ```kotlin
 import com.yonatankarp.ff4k.dsl.core.ff4k
 
-val ff4k = ff4k {
-    features {
-        feature("dark-mode") {
-            isEnabled = true
-            description = "Enable dark mode theme"
+suspend fun main() {
+    val ff4k = ff4k {
+        features {
+            feature("dark-mode") {
+                isEnabled = true
+                description = "Enable dark mode theme"
+            }
         }
     }
-}
 
-// Check feature status
-if (ff4k.check("dark-mode")) {
-    // ...
+    // Check feature status
+    ff4k.ifEnabled("dark-mode") {
+        // ...
+    }
 }
 ```
 

--- a/docs/properties.md
+++ b/docs/properties.md
@@ -28,15 +28,17 @@ FF4K comes with support for common data types out of the box:
 You can define properties within the `properties` block of the `ff4k` DSL.
 
 ```kotlin
-ff4k {
-    properties {
-        property("app-title") {
-            value = "My Awesome App"
-        }
-        
-        property("max-connections") {
-            value = 10
-            description = "Maximum number of concurrent connections"
+suspend fun main() {
+    val ff4k = ff4k {
+        properties {
+            property("app-title") {
+                value = "My Awesome App"
+            }
+
+            property("max-connections") {
+                value = 10
+                description = "Maximum number of concurrent connections"
+            }
         }
     }
 }
@@ -79,14 +81,30 @@ data class PropertyColor(
 
 ### 2. Using Custom Properties
 
-You can manually add custom properties to the store if you are not using the DSL builder for them, or extend the DSL if you want seamless integration.
-
-To use them with the `ff4k` instance:
+You can manually add custom properties to the store. Here is a complete example of how to register and use a custom property type:
 
 ```kotlin
-val myColor = PropertyColor("bg-color", "#FFFFFF")
-// Assuming you have access to the underlying store or use a custom mechanism to register it
-// ff4k.getPropertyStore().createProperty(myColor)
-```
+suspend fun main() {
+    // 1. Initialize your property store
+    val myPropertyStore = InMemoryPropertyStore()
 
-*Note: The DSL currently simplifies the creation of built-in types. Custom types can be instantiated and added to your `PropertyStore` directly.*
+    // 2. Initialize FF4K with your store
+    val ff4k = ff4k(propertyStore = myPropertyStore) {
+        // ... other configuration ...
+    }
+
+    // 3. Create your custom property
+    val brandColor = PropertyColor(
+        name = "brand-color",
+        value = "#FF5722",
+        description = "Primary brand color"
+    )
+
+    // 4. Add it to the store manually
+    myPropertyStore += brandColor
+
+    // 5. Retrieve and use it
+    val storedColor = ff4k.property<String>("brand-color")
+    println("Brand Color: ${storedColor?.value}") // Output: #FF5722
+}
+```

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -9,8 +9,10 @@ The entry point for FF4K is the `ff4k` DSL function. It allows you to configure 
 ```kotlin
 import com.yonatankarp.ff4k.dsl.core.ff4k
 
-val ff4k = ff4k {
-    // Configuration block
+suspend fun main() {
+    val ff4k = ff4k {
+        // Configuration block
+    }
 }
 ```
 
@@ -19,12 +21,14 @@ val ff4k = ff4k {
 The `ff4k` function accepts several optional arguments to customize behavior:
 
 ```kotlin
-val ff4k = ff4k(
-    autoCreate = true,                // Automatically create missing features (default: false)
-    featureStore = InMemoryFeatureStore(), // Custom feature store (default: InMemory)
-    propertyStore = InMemoryPropertyStore() // Custom property store (default: InMemory)
-) {
-    // ...
+suspend fun main() {
+    val ff4k = ff4k(
+        autoCreate = true,                // Automatically create missing features (default: false)
+        featureStore = InMemoryFeatureStore(), // Custom feature store (default: InMemory)
+        propertyStore = InMemoryPropertyStore() // Custom property store (default: InMemory)
+    ) {
+        // ...
+    }
 }
 ```
 
@@ -37,17 +41,19 @@ val ff4k = ff4k(
 Features are boolean flags that can be toggled on or off. You can define them within the `features` block.
 
 ```kotlin
-ff4k {
-    features {
-        // Minimal definition
-        feature("simple-feature")
+suspend fun main() {
+    val ff4k = ff4k {
+        features {
+            // Minimal definition
+            feature("simple-feature")
 
-        // Detailed definition
-        feature("advanced-feature") {
-            isEnabled = true
-            description = "Controls the new dashboard layout"
-            group = "ui-beta"
-            permissions("ADMIN", "BETA_TESTER")
+            // Detailed definition
+            feature("advanced-feature") {
+                isEnabled = true
+                description = "Controls the new dashboard layout"
+                group = "ui-beta"
+                permissions("ADMIN", "BETA_TESTER")
+            }
         }
     }
 }
@@ -66,19 +72,21 @@ ff4k {
 Properties are key-value pairs that can store configuration data. They are strongly typed.
 
 ```kotlin
-ff4k {
-    properties {
-        // String property
-        property("api-url") {
-            value = "https://api.example.com"
-        }
+suspend fun main() {
+    val ff4k = ff4k {
+        properties {
+            // String property
+            property("api-url") {
+                value = "https://api.example.com"
+            }
 
-        // Integer property with constraints
-        property("max-retries") {
-            value = 3
-            description = "Max API retries"
-            fixedValues(1, 3, 5) // Value must be one of these
-            readOnly = true // Prevent runtime modification
+            // Integer property with constraints
+            property("max-retries") {
+                value = 3
+                description = "Max API retries"
+                fixedValues(1, 3, 5) // Value must be one of these
+                readOnly = true // Prevent runtime modification
+            }
         }
     }
 }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -34,7 +34,7 @@ nav:
   - Properties: properties.md
   - Testing: testing.md
   - Extending: extending.md
-  - API Reference: api/index.html
+  - API Reference: https://yonatankarp.github.io/ff4k/api/
 
 markdown_extensions:
   - pymdownx.highlight:


### PR DESCRIPTION
The documentation examples previously showed ff4k DSL calls as top-level
code without any coroutine context. Since ff4k is a suspend function,
this could mislead users about proper usage. All examples now wrap code
in suspend fun main() to demonstrate the correct way to call suspend
functions without encouraging blocking patterns like runBlocking.

The quick start example now uses the ifEnabled extension function
instead of the check() method with an if statement, showcasing the more
idiomatic Kotlin approach for feature flag checks.

The CI workflow has been updated to use newer versions of GitHub Actions
(checkout@v6, setup-python@v6, setup-java@v5) and the correct Dokka
command (dokkaGenerateHtml instead of dokkaHtmlMultiModule) to match
the current Dokka configuration.

The API reference link in mkdocs.yml now points to the correct external
URL instead of a relative path that would not resolve properly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Reworked examples to use an explicit suspending main entry, clearer initialization patterns, and lambda-based feature checks.
  * Added concrete in-memory store examples with full CRUD-like workflows for features and properties.
  * Minor docs polish (capitalization and example clarity).

* **Chores**
  * Updated CI tooling and documentation generation workflow versions and adjusted documentation output paths.
* **Config**
  * Pointed API Reference navigation to the external docs site.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->