### PR TITLE
chore: Improve CI workflow and add test resource configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,7 @@ jobs:
     needs: code-quality
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         include:
           - target: jvm
@@ -75,6 +76,7 @@ jobs:
     needs: code-quality
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         include:
           - target: iosSimulatorArm64

--- a/build-logic/src/main/kotlin/ff4k.multiplatform.gradle.kts
+++ b/build-logic/src/main/kotlin/ff4k.multiplatform.gradle.kts
@@ -1,5 +1,6 @@
 import org.gradle.api.artifacts.VersionCatalogsExtension
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.targets.native.tasks.KotlinNativeTest
 
 plugins {
     id("org.jetbrains.kotlin.multiplatform")
@@ -89,6 +90,17 @@ android {
             isReturnDefaultValues = true
         }
     }
+    sourceSets {
+        named("test") {
+            resources.srcDir("src/commonTest/resources")
+        }
+    }
+}
+
+// Configure native test tasks to find test resources
+val resourcesDir = project.file("src/commonTest/resources")
+tasks.withType<KotlinNativeTest> {
+    environment("FF4K_RESOURCES_PATH", resourcesDir.absolutePath)
 }
 
 spotless {


### PR DESCRIPTION
- Set fail-fast: false on CI matrix jobs to run all targets even if one fails
- Configure Android sourceSets to include commonTest resources
- Set `FF4K_RESOURCES_PATH` environment variable for native test tasks
- Fix missing newline at end of ci.yml

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved CI/CD pipeline resilience to continue testing all platforms even when one encounters a build failure
  * Enhanced native test infrastructure to properly access test resources at runtime

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->