### PR TITLE
feat: migrate publishing from GitHub Packages to Maven Central

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -6,20 +6,10 @@ on:
       - 'v*'
 
 jobs:
-  publish-linux:
-    runs-on: ubuntu-latest
+  publish:
+    runs-on: macos-latest
     permissions:
       contents: write
-      packages: write
-    strategy:
-      matrix:
-        include:
-          - target: jvm
-            test: jvmTest
-            task: publishJvmPublicationToGitHubPackagesRepository
-          - target: android
-            test: testDebugUnitTest
-            task: publishAndroidReleasePublicationToGitHubPackagesRepository
 
     steps:
       - name: Checkout code
@@ -32,7 +22,6 @@ jobs:
           java-version: '17'
 
       - name: Setup Android SDK
-        if: matrix.target == 'android'
         uses: android-actions/setup-android@v3
 
       - name: Setup Gradle
@@ -44,70 +33,19 @@ jobs:
         id: version
         run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
 
-      - name: Test ${{ matrix.target }}
-        run: ./gradlew ${{ matrix.test }} --no-daemon
+      - name: Run all tests
+        run: ./gradlew check --no-daemon
 
-      - name: Publish ${{ matrix.target }}
-        run: ./gradlew "-Pversion=${{ steps.version.outputs.VERSION }}" ${{ matrix.task }} --no-daemon
+      - name: Publish to Maven Central
+        run: ./gradlew publishAllPublicationsToMavenCentralRepository "-Pversion=${{ steps.version.outputs.VERSION }}" --no-daemon
         env:
-          GITHUB_ACTOR: ${{ github.actor }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
-          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
-
-  publish-ios:
-    runs-on: ${{ matrix.os }}
-    permissions:
-      contents: write
-      packages: write
-    strategy:
-      matrix:
-        include:
-          - target: iosArm64
-            os: macos-latest
-            test: linkDebugTestIosArm64
-            task: publishIosArm64PublicationToGitHubPackagesRepository
-          - target: iosSimulatorArm64
-            os: macos-latest
-            test: iosSimulatorArm64Test
-            task: publishIosSimulatorArm64PublicationToGitHubPackagesRepository
-          - target: iosX64
-            os: macos-15-intel
-            test: iosX64Test
-            task: publishIosX64PublicationToGitHubPackagesRepository
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-
-      - name: Set up JDK 17
-        uses: actions/setup-java@v5
-        with:
-          distribution: 'temurin'
-          java-version: '17'
-
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v5
-        with:
-          cache-read-only: false
-
-      - name: Extract version from tag
-        id: version
-        run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
-
-      - name: Test ${{ matrix.target }}
-        run: ./gradlew ${{ matrix.test }} --no-daemon
-
-      - name: Publish ${{ matrix.target }}
-        run: ./gradlew "-Pversion=${{ steps.version.outputs.VERSION }}" ${{ matrix.task }} --no-daemon
-        env:
-          GITHUB_ACTOR: ${{ github.actor }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
-          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.GPG_PRIVATE_KEY }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.GPG_PASSPHRASE }}
 
   create-release:
-    needs: [publish-linux, publish-ios]
+    needs: publish
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -14,4 +14,5 @@ dependencies {
     implementation(libs.spotless.gradle.plugin)
     implementation(libs.kover.gradle.plugin)
     implementation(libs.dokka.gradle.plugin)
+    implementation(libs.maven.publish.gradle.plugin)
 }

--- a/build-logic/src/main/kotlin/ff4k.multiplatform.gradle.kts
+++ b/build-logic/src/main/kotlin/ff4k.multiplatform.gradle.kts
@@ -75,7 +75,7 @@ dependencies {
 }
 
 android {
-    namespace = "org.ff4k.${project.name.replace("-", ".")}"
+    namespace = "com.yonatankarp.${project.name.replace("-", ".")}"
     compileSdk = 34
     defaultConfig {
         minSdk = 24

--- a/build-logic/src/main/kotlin/ff4k.publish.gradle.kts
+++ b/build-logic/src/main/kotlin/ff4k.publish.gradle.kts
@@ -1,76 +1,56 @@
-import org.gradle.api.publish.maven.MavenPublication
-import org.gradle.kotlin.dsl.configure
-import org.gradle.kotlin.dsl.withType
-import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
+import com.vanniktech.maven.publish.JavadocJar
+import com.vanniktech.maven.publish.KotlinMultiplatform
 
 plugins {
-    `maven-publish`
-    signing
+    id("org.jetbrains.dokka")
+    id("com.vanniktech.maven.publish")
 }
 
-plugins.withId("org.jetbrains.kotlin.multiplatform") {
-    configure<KotlinMultiplatformExtension> {
-        jvm {
-            withSourcesJar()
-        }
-    }
-}
+mavenPublishing {
+    configure(
+        KotlinMultiplatform(
+            javadocJar = JavadocJar.Dokka("dokkaGeneratePublicationHtml"),
+            sourcesJar = true,
+            androidVariantsToPublish = listOf("release")
+        )
+    )
 
-publishing {
-    publications.withType<MavenPublication> {
-        groupId = project.group.toString()
+    publishToMavenCentral()
+    signAllPublications()
+
+    coordinates(
+        groupId = project.group.toString(),
+        artifactId = project.name,
         version = project.version.toString()
+    )
 
-        pom {
-            name.set(project.name)
-            description.set("FF4K - Kotlin Multiplatform feature flag library")
+    pom {
+        name.set(project.name)
+        description.set("FF4K - Kotlin Multiplatform feature flag library")
+        url.set("https://github.com/yonatankarp/ff4k")
+        inceptionYear.set("2025")
+
+        licenses {
+            license {
+                name.set("The Apache License, Version 2.0")
+                url.set("https://www.apache.org/licenses/LICENSE-2.0.txt")
+                distribution.set("repo")
+            }
+        }
+
+        developers {
+            developer {
+                id.set("yonatankarp")
+                name.set("Yonatan Karp-Rudin")
+                email.set("yonvata@gmail.com")
+                url.set("https://github.com/yonatankarp")
+            }
+        }
+
+        scm {
+            connection.set("scm:git:git://github.com/yonatankarp/ff4k.git")
+            developerConnection.set("scm:git:ssh://git@github.com/yonatankarp/ff4k.git")
             url.set("https://github.com/yonatankarp/ff4k")
-
-            licenses {
-                license {
-                    name.set("The Apache License, Version 2.0")
-                    url.set("https://www.apache.org/licenses/LICENSE-2.0.txt")
-                }
-            }
-
-            developers {
-                developer {
-                    id.set("yonatankarp")
-                    name.set("Yonatan Karp-Rudin")
-                    email.set("yonvata@gmail.com")
-                }
-            }
-
-            scm {
-                connection.set("scm:git:git://github.com/yonatankarp/ff4k.git")
-                developerConnection.set("scm:git:ssh://git@github.com/yonatankarp/ff4k.git")
-                url.set("https://github.com/yonatankarp/ff4k")
-            }
         }
     }
-
-    repositories {
-        maven {
-            name = "GitHubPackages"
-            url = uri("https://maven.pkg.github.com/yonatankarp/ff4k")
-            credentials {
-                username = System.getenv("GITHUB_ACTOR")
-                password = System.getenv("GITHUB_TOKEN")
-            }
-        }
-    }
-}
-
-signing {
-    val signingKey = System.getenv("GPG_PRIVATE_KEY")
-    val signingPassword = System.getenv("GPG_PASSPHRASE")
-
-    val hasSigningKeys = signingKey != null && signingPassword != null
-
-    if (hasSigningKeys) {
-        useInMemoryPgpKeys(signingKey, signingPassword)
-        sign(publishing.publications)
-    }
-
-    isRequired = hasSigningKeys && !version.toString().endsWith("SNAPSHOT")
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,6 +13,7 @@ serialization = "1.7.0"
 slf4j = "2.0.9"
 spotless = "8.1.0"
 kotest = "5.9.1"
+maven-publish = "0.34.0"
 
 [libraries]
 # KMP Common
@@ -33,6 +34,7 @@ android-gradle-plugin = { module = "com.android.tools.build:gradle", version.ref
 spotless-gradle-plugin = { module = "com.diffplug.spotless:spotless-plugin-gradle", version.ref = "spotless" }
 kover-gradle-plugin = { module = "org.jetbrains.kotlinx:kover-gradle-plugin", version.ref = "kover" }
 dokka-gradle-plugin = { module = "org.jetbrains.dokka:dokka-gradle-plugin", version.ref = "dokka" }
+maven-publish-gradle-plugin = { module = "com.vanniktech:gradle-maven-publish-plugin", version.ref = "maven-publish" }
 
 # Testing
 robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectric" }
@@ -53,6 +55,7 @@ kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }
 kover = { id = "org.jetbrains.kotlinx.kover", version.ref = "kover" }
 dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
+maven-publish = { id = "com.vanniktech.maven.publish", version.ref = "maven-publish" }
 
 [bundles]
 


### PR DESCRIPTION
This change makes ff4k accessible to all Kotlin/Java developers without requiring GitHub authentication or custom repository configuration. Maven Central is the standard distribution channel for JVM libraries.

The vanniktech gradle-maven-publish-plugin replaces the manual maven-publish setup, following the official Kotlin multiplatform documentation. The plugin handles publication configuration, POM metadata, and GPG signing for all targets (JVM, Android, iOS).

The Android namespace changed from `org.ff4k.*` to `com.yonatankarp.*` to align with the Maven Central group ID requirement.

The CI workflow is simplified to a single macOS job that builds and publishes all platform targets in one step, replacing the previous multi-job matrix strategy for GitHub Packages.

Closes #116

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Android package namespace configuration.
  * Streamlined publishing workflow and consolidated multi-platform publishing into a unified process.
  * Enhanced project metadata including license information, developer details, and repository configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->