### PR TITLE
bugfix: Disable Sonar Cloud scan for dependabot

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,6 +114,7 @@ jobs:
   sonarcloud:
     needs: [build-linux, build-ios]
     runs-on: ubuntu-latest
+    if: github.actor != 'dependabot[bot]'
     steps:
       - name: Checkout code
         uses: actions/checkout@v6


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow configuration to prevent SonarCloud code quality analysis from executing when workflows are triggered by automated dependency update tools. This optimization reduces unnecessary processing overhead and ensures quality scans focus on user-initiated code changes rather than automated dependency updates.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->