### PR TITLE
feat: Fix CI widget

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,88 @@
+name: Bug Report
+description: Report a bug or unexpected behavior
+labels: [bug]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug! Please fill out the information below to help us investigate.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A clear and concise description of the bug.
+      placeholder: What happened? What did you expect to happen?
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to Reproduce
+      description: Minimal code or steps to reproduce the issue.
+      placeholder: |
+        1. Configure FF4K with...
+        2. Call...
+        3. See error...
+      render: kotlin
+    validations:
+      required: true
+
+  - type: dropdown
+    id: platform
+    attributes:
+      label: Platform
+      description: Which platform(s) are affected?
+      multiple: true
+      options:
+        - JVM
+        - Android
+        - iOS
+    validations:
+      required: true
+
+  - type: input
+    id: ff4k-version
+    attributes:
+      label: FF4K Version
+      description: Which version of FF4K are you using?
+      placeholder: e.g., 0.1.0
+    validations:
+      required: true
+
+  - type: input
+    id: kotlin-version
+    attributes:
+      label: Kotlin Version
+      description: Which version of Kotlin are you using?
+      placeholder: e.g., 2.0.0
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Any additional environment details (OS, JDK version, Android API level, iOS version, etc.)
+      placeholder: |
+        - OS: macOS 14.0
+        - JDK: 17
+        - Android API: 34
+
+  - type: textarea
+    id: stacktrace
+    attributes:
+      label: Stack Trace / Logs
+      description: If applicable, paste relevant error logs or stack traces.
+      render: shell
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Checklist
+      options:
+        - label: I have searched existing issues to ensure this bug hasn't been reported
+          required: true
+        - label: I am using the latest version of FF4K
+          required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Documentation
+    url: https://yonatankarp.github.io/ff4k/
+    about: Check the documentation for usage guides and API reference
+  - name: Questions & Discussions
+    url: https://github.com/yonatankarp/ff4k/discussions
+    about: Ask questions or start a discussion (not for bug reports)

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,70 @@
+name: Feature Request
+description: Suggest a new feature or enhancement
+labels: [enhancement]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting a feature! Please describe what you'd like to see added to FF4K.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem Statement
+      description: What problem does this feature solve? Is it related to a frustration?
+      placeholder: I'm always frustrated when...
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed Solution
+      description: Describe the solution you'd like to see.
+      placeholder: I would like FF4K to...
+    validations:
+      required: true
+
+  - type: textarea
+    id: api
+    attributes:
+      label: API Design (Optional)
+      description: If you have ideas for how the API should look, share them here.
+      placeholder: |
+        // Example usage
+        ff4k {
+            features {
+                feature("my-feature") {
+                    // new functionality here
+                }
+            }
+        }
+      render: kotlin
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+      description: Any alternative solutions or features you've considered?
+
+  - type: dropdown
+    id: platform
+    attributes:
+      label: Applicable Platform(s)
+      description: Which platform(s) would this feature apply to?
+      multiple: true
+      options:
+        - All platforms
+        - JVM
+        - Android
+        - iOS
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Checklist
+      options:
+        - label: I have searched existing issues to ensure this feature hasn't been requested
+          required: true
+        - label: I would be willing to contribute this feature
+          required: false

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,32 @@
+## Summary
+
+<!-- Brief description of the changes (1-3 sentences) -->
+
+## Motivation
+
+<!-- Why is this change needed? Link to related issue if applicable -->
+
+Closes #
+
+## Changes
+
+<!-- What does this PR do? List the main changes -->
+
+-
+
+## Testing
+
+<!-- How did you test these changes? -->
+
+- [ ] Unit tests added/updated
+- [ ] Tested on JVM
+- [ ] Tested on Android
+- [ ] Tested on iOS
+
+## Checklist
+
+- [ ] My code follows the project's code style (`./gradlew spotlessCheck` passes)
+- [ ] I have added tests that prove my fix/feature works
+- [ ] All tests pass (`./gradlew check`)
+- [ ] I have updated documentation if needed
+- [ ] I marked all checkboxes without reading

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,43 @@
+# Configuration for auto-generated release notes
+# https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes
+
+changelog:
+  exclude:
+    labels:
+      - skip-changelog
+    authors:
+      - dependabot
+      - dependabot[bot]
+      - github-actions
+      - github-actions[bot]
+
+  categories:
+    - title: "Breaking Changes"
+      labels:
+        - breaking
+        - breaking-change
+
+    - title: "New Features"
+      labels:
+        - enhancement
+        - feature
+
+    - title: "Bug Fixes"
+      labels:
+        - bug
+        - fix
+        - bugfix
+
+    - title: "Documentation"
+      labels:
+        - documentation
+        - docs
+
+    - title: "Dependencies"
+      labels:
+        - dependencies
+        - dependency
+
+    - title: "Other Changes"
+      labels:
+        - "*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,32 @@ on:
     branches: [ "main" ]
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      source: ${{ steps.filter.outputs.source }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Detect changes
+        uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            source:
+              - '**/*.kt'
+              - '**/*.kts'
+              - 'gradle/**'
+              - 'gradle.properties'
+              - '.github/workflows/ci.yml'
+
   code-quality:
+    needs: changes
+    if: needs.changes.outputs.source == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -32,7 +57,8 @@ jobs:
         run: ./gradlew spotlessCheck --no-daemon
 
   build-linux:
-    needs: code-quality
+    needs: [changes, code-quality]
+    if: needs.changes.outputs.source == 'true'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -73,7 +99,8 @@ jobs:
           retention-days: 1
 
   build-ios:
-    needs: code-quality
+    needs: [changes, code-quality]
+    if: needs.changes.outputs.source == 'true'
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -112,9 +139,9 @@ jobs:
           retention-days: 1
 
   sonarcloud:
-    needs: [build-linux, build-ios]
+    needs: [changes, build-linux, build-ios]
+    if: needs.changes.outputs.source == 'true' && github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
-    if: github.actor != 'dependabot[bot]'
     steps:
       - name: Checkout code
         uses: actions/checkout@v6

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,175 @@
+# Contributing to FF4K
+
+Thank you for your interest in contributing to FF4K! This document provides guidelines and information to help you contribute effectively.
+
+## Getting Started
+
+### Prerequisites
+
+- JDK 17 or later
+- Gradle 8.x (wrapper included)
+
+### Building the Project
+
+```bash
+./gradlew build
+```
+
+### Running Tests
+
+```bash
+# Run all tests
+./gradlew check
+
+# Run JVM tests only
+./gradlew jvmTest
+
+# Run Android tests only
+./gradlew testDebugUnitTest
+
+# Run iOS tests (requires macOS)
+./gradlew iosSimulatorArm64Test
+```
+
+### Checking Code Formatting
+
+```bash
+# Check formatting
+./gradlew spotlessCheck
+
+# Auto-fix formatting
+./gradlew spotlessApply
+```
+
+## Making Changes
+
+### Branch Naming
+
+Use descriptive branch names with the following prefixes:
+
+| Prefix      | Purpose               | Example                      |
+|-------------|-----------------------|------------------------------|
+| `feature/`  | New features          | `feature/add-redis-store`    |
+| `fix/`      | Bug fixes             | `fix/property-serialization` |
+| `docs/`     | Documentation changes | `docs/update-readme`         |
+| `chore/`    | Maintenance tasks     | `chore/update-dependencies`  |
+| `refactor/` | Code refactoring      | `refactor/simplify-dsl`      |
+
+### Commit Messages
+
+We follow [Conventional Commits](https://www.conventionalcommits.org/) for clear and consistent commit history.
+
+**Format:**
+```
+<type>(<scope>): <description>
+
+[optional body]
+
+[optional footer(s)]
+```
+
+**Types:**
+
+| Type       | Description                                             |
+|------------|---------------------------------------------------------|
+| `feat`     | A new feature                                           |
+| `fix`      | A bug fix                                               |
+| `docs`     | Documentation-only changes                              |
+| `style`    | Code style changes (formatting, etc.)                   |
+| `refactor` | Code change that neither fixes a bug nor adds a feature |
+| `perf`     | Performance improvement                                 |
+| `test`     | Adding or updating tests                                |
+| `chore`    | Maintenance tasks, dependency updates                   |
+| `ci`       | CI/CD configuration changes                             |
+
+**Examples:**
+```
+feat(dsl): add support for feature groups
+
+fix(store): resolve race condition in InMemoryFeatureStore
+
+docs: update installation instructions in README
+
+chore(deps): bump kotlin to 2.1.0
+```
+
+### Pull Requests
+
+#### PR Title
+
+PR titles should follow the same format as commit messages:
+```
+<type>(<scope>): <description>
+```
+
+This ensures clear release notes when your PR is merged.
+
+#### PR Labels
+
+Add appropriate labels to your PR. These labels are used to categorize changes in release notes:
+
+| Label                           | Use When                                       |
+|---------------------------------|------------------------------------------------|
+| `enhancement` or `feature`      | Adding new functionality                       |
+| `bug` or `fix`                  | Fixing a bug                                   |
+| `documentation` or `docs`       | Documentation changes                          |
+| `dependencies`                  | Dependency updates                             |
+| `breaking` or `breaking-change` | Introducing breaking changes                   |
+| `skip-changelog`                | Changes that shouldn't appear in release notes |
+
+#### PR Description
+
+Please include:
+- **What**: A brief description of the changes
+- **Why**: The motivation or issue being addressed
+- **How**: Any notable implementation details
+- **Testing**: How you tested the changes
+
+### Code Quality
+
+Before submitting a PR, ensure:
+
+1. **Tests pass**: `./gradlew check`
+2. **Code compiles**: `./gradlew build`
+3. **Formatting is correct**: `./gradlew spotlessCheck`
+
+The CI pipeline will automatically run:
+- Code formatting check via Spotless (ktlint)
+- Unit tests on JVM and Android (Linux)
+- Unit tests on iOS Simulator (macOS)
+- Code coverage merged and reported to SonarCloud
+
+### Testing
+
+We use [Kotest](https://kotest.io/) for testing. Tests should be written using Kotest's DSL:
+
+```kotlin
+class MyFeatureTest : FunSpec({
+    test("should do something") {
+        // Given
+        val input = "test"
+
+        // When
+        val result = myFunction(input)
+
+        // Then
+        result shouldBe "expected"
+    }
+})
+```
+
+### Breaking Changes
+
+If your change introduces breaking changes:
+
+1. Add the `breaking` label to your PR
+2. Document the breaking change in the PR description
+3. Explain migration steps for users
+
+## Questions?
+
+If you have questions or need help, feel free to open a [GitHub Issue](https://github.com/yonatankarp/ff4k/issues).
+
+## License
+
+By contributing to FF4K, you agree that your contributions will be licensed under the [Apache License 2.0](LICENSE).

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,190 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to the Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   Copyright 2025 Yonatan Karp-Rudin
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 <div align="center">
 
-[![CI](https://github.com/yonatankarp/ff4k/actions/workflows/ci.yml/badge.svg)](https://github.com/yonatankarp/ff4k/actions/workflows/ci.yml)
+[![CI](https://github.com/yonatankarp/ff4k/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/yonatankarp/ff4k/actions/workflows/ci.yml)
+[![Documentation](https://img.shields.io/badge/docs-GitHub%20Pages-blue)](https://yonatankarp.github.io/ff4k/)
 [![License Apache2](https://img.shields.io/hexpm/l/plug.svg)](http://www.apache.org/licenses/LICENSE-2.0)
 [![Kotlin](https://img.shields.io/badge/kotlin-2.0.0-blue.svg?logo=kotlin)](https://kotlinlang.org)
 [![JVM](https://img.shields.io/badge/JVM-17-orange.svg?logo=openjdk)](https://openjdk.org/)
@@ -120,6 +121,14 @@ ff4k.enableGroup("ui-experiments")
 ff4k.disableGroup("ui-experiments")
 ```
 
+## Contributing
+
+Contributions are welcome! Please read our [Contributing Guidelines](CONTRIBUTING.md) before submitting a pull request.
+
+## Security
+
+To report a security vulnerability, please see our [Security Policy](SECURITY.md).
+
 ## License
 
-This project is licensed under the Apache License 2.0.
+This project is licensed under the [Apache License 2.0](LICENSE).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,40 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+We take security vulnerabilities seriously. If you discover a security issue, please report it responsibly.
+
+### How to Report
+
+**Please do NOT report security vulnerabilities through public GitHub issues.**
+
+Instead, please report them use [GitHub's private vulnerability reporting](https://github.com/yonatankarp/ff4k/security/advisories/new).
+
+### What to Include
+
+- Description of the vulnerability
+- Steps to reproduce the issue
+- Potential impact
+- Suggested fix (if any)
+
+### What to Expect
+
+- **Acknowledgment**: We will acknowledge receipt of your report within 48 hours.
+- **Updates**: We will keep you informed of our progress.
+- **Resolution**: We aim to resolve critical vulnerabilities within 30 days.
+- **Credit**: We will credit you in the release notes (unless you prefer to remain anonymous).
+
+### Scope
+
+This security policy applies to:
+- The FF4K core library (`ff4k-core`)
+- Official FF4K modules and extensions
+- Build and CI/CD configurations
+
+## Security Best Practices
+
+When using FF4K in your applications:
+
+1. **Keep dependencies updated**: Regularly update to the latest FF4K version
+2. **Validate feature flag sources**: If loading flags from external sources, validate and sanitize inputs
+3. **Audit permissions**: Review feature flag permissions in production configurations


### PR DESCRIPTION
This change improves the README file by making sure that the CI widget points to the `main` branch and not for any random execution of the pipeline. Moreover it adds link to the docs for easy discovery


Additionally: 

- Add CONTRIBUTING.md with commit/PR conventions
- Add SECURITY.md with vulnerability reporting policy
- Add LICENSE (Apache 2.0)
- Add issue templates (bug report, feature request)
- Add pull request template
- Add release.yml for categorized release notes
- Update README with Contributing/Security links
- Optimize CI to skip tests for docs-only changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added CONTRIBUTING, SECURITY, and LICENSE files; updated README badges and links.

* **Templates**
  * Added standard issue and pull-request templates for bug reports, feature requests, and PRs to guide contributors.

* **CI / Release**
  * Added automated release-notes configuration and enhanced CI workflows to detect source changes and conditionally run jobs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->