### PR TITLE
feat(strategy): Add composite flipping strategies (AND, OR, NOT)

### DIFF
--- a/ff4k-contract-test/src/commonMain/kotlin/com/yonatankarp/ff4k/test/contract/strategy/FlippingStrategyContractTest.kt
+++ b/ff4k-contract-test/src/commonMain/kotlin/com/yonatankarp/ff4k/test/contract/strategy/FlippingStrategyContractTest.kt
@@ -5,12 +5,10 @@ package com.yonatankarp.ff4k.test.contract.strategy
 import com.yonatankarp.ff4k.core.FeatureStore
 import com.yonatankarp.ff4k.core.FlippingExecutionContext
 import com.yonatankarp.ff4k.core.FlippingStrategy
-import com.yonatankarp.ff4k.serialization.ff4kSerializersModule
+import com.yonatankarp.ff4k.serialization.FF4kJson
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import kotlinx.serialization.PolymorphicSerializer
-import kotlinx.serialization.json.Json
-import kotlinx.serialization.modules.SerializersModule
 
 /**
  * Contract test for FlippingStrategy implementations.
@@ -46,13 +44,6 @@ abstract class FlippingStrategyContractTest : FunSpec() {
      * The JSON should include the polymorphic type discriminator if applicable.
      */
     protected abstract fun expectedJsonForSampleParams(): String
-
-    /**
-     * The SerializersModule to use for serialization tests.
-     * Defaults to [ff4kSerializersModule].
-     * Override this to register the strategy implementation being tested if it's not in the default module.
-     */
-    protected open val serializersModule: SerializersModule = ff4kSerializersModule
 
     init {
         test("should store init params") {
@@ -110,16 +101,11 @@ abstract class FlippingStrategyContractTest : FunSpec() {
             // Given
             val initParams = sampleInitParams()
             val strategy = createStrategy(initParams)
-            val json = Json {
-                serializersModule = this@FlippingStrategyContractTest.serializersModule
-                prettyPrint = true
-                ignoreUnknownKeys = true
-            }
-            val expectedJson = json.parseToJsonElement(expectedJsonForSampleParams())
+            val expectedJson = FF4kJson.parseToJsonElement(expectedJsonForSampleParams())
 
             // When
             val serializer = PolymorphicSerializer(FlippingStrategy::class)
-            val actualJson = json.encodeToJsonElement(serializer, strategy)
+            val actualJson = FF4kJson.encodeToJsonElement(serializer, strategy)
 
             // Then
             actualJson shouldBe expectedJson
@@ -129,16 +115,11 @@ abstract class FlippingStrategyContractTest : FunSpec() {
             // Given
             val initParams = sampleInitParams()
             val strategy = createStrategy(initParams)
-            val json = Json {
-                serializersModule = this@FlippingStrategyContractTest.serializersModule
-                prettyPrint = true
-                ignoreUnknownKeys = true
-            }
             val jsonString = expectedJsonForSampleParams()
 
             // When
             val serializer = PolymorphicSerializer(FlippingStrategy::class)
-            val deserialized = json.decodeFromString(serializer, jsonString)
+            val deserialized = FF4kJson.decodeFromString(serializer, jsonString)
 
             // Then
             deserialized.initParams shouldBe strategy.initParams

--- a/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/core/FlippingStrategy.kt
+++ b/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/core/FlippingStrategy.kt
@@ -66,10 +66,19 @@ interface FlippingStrategy {
      * @param context execution context containing runtime parameters (user info, region, etc.)
      * @return `true` if the feature should be enabled, `false` otherwise
      */
-    // TODO - will be implemented in Phase 2
     suspend fun evaluate(
         featureId: String,
         store: FeatureStore?,
         context: FlippingExecutionContext,
-    ): Boolean = true
+    ): Boolean
+
+    /**
+     * Asserts that a required parameter exists in [initParams].
+     *
+     * @param paramName The name of the required parameter.
+     * @throws IllegalArgumentException if the parameter is not present.
+     */
+    fun assertRequiredParameter(paramName: String) {
+        require(paramName in initParams.keys) { "Parameter '$paramName' is required for this FlippingStrategy" }
+    }
 }

--- a/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/serialization/FF4kSerializersModule.kt
+++ b/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/serialization/FF4kSerializersModule.kt
@@ -17,6 +17,12 @@ import com.yonatankarp.ff4k.property.PropertyLogLevel
 import com.yonatankarp.ff4k.property.PropertyLong
 import com.yonatankarp.ff4k.property.PropertyShort
 import com.yonatankarp.ff4k.property.PropertyString
+import com.yonatankarp.ff4k.strategy.AlwaysFalseFlippingStrategy
+import com.yonatankarp.ff4k.strategy.AlwaysTrueFlippingStrategy
+import com.yonatankarp.ff4k.strategy.AndStrategy
+import com.yonatankarp.ff4k.strategy.NotStrategy
+import com.yonatankarp.ff4k.strategy.OrStrategy
+import kotlinx.serialization.json.Json
 import kotlinx.serialization.modules.SerializersModule
 import kotlinx.serialization.modules.plus
 import kotlinx.serialization.modules.polymorphic
@@ -40,6 +46,24 @@ val ff4kSerializersModule = SerializersModule {
     }
 
     polymorphic(FlippingStrategy::class) {
-        // Register FlippingStrategy implementations here as they are created
+        subclass(AndStrategy::class, AndStrategy.serializer())
+        subclass(OrStrategy::class, OrStrategy.serializer())
+        subclass(NotStrategy::class, NotStrategy.serializer())
+        subclass(AlwaysTrueFlippingStrategy::class, AlwaysTrueFlippingStrategy.serializer())
+        subclass(AlwaysFalseFlippingStrategy::class, AlwaysFalseFlippingStrategy.serializer())
     }
 } + humanReadableSerializerModule
+
+/**
+ * Pre-configured [Json] instance with FF4k serializers module.
+ *
+ * Configured with:
+ * - [ff4kSerializersModule] for polymorphic serialization of FF4k types
+ * - `ignoreUnknownKeys = true` for forward compatibility
+ * - `prettyPrint = true` for readable output
+ */
+val FF4kJson = Json {
+    serializersModule = ff4kSerializersModule
+    ignoreUnknownKeys = true
+    prettyPrint = true
+}

--- a/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/strategy/CompositeFlippingStrategies.kt
+++ b/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/strategy/CompositeFlippingStrategies.kt
@@ -1,0 +1,55 @@
+package com.yonatankarp.ff4k.strategy
+
+import com.yonatankarp.ff4k.core.FlippingStrategy
+
+/**
+ * Combines this strategy with [other] using logical AND.
+ *
+ * If this strategy is already an [AndStrategy], the [other] strategy is appended
+ * to its list, creating a flat structure instead of nesting.
+ *
+ * Example:
+ * ```kotlin
+ * val strategy = strategyA and strategyB and strategyC
+ * // Creates AndStrategy([a, b, c]) instead of AndStrategy([AndStrategy([a, b]), c])
+ * ```
+ *
+ * @param other The strategy to combine with.
+ * @return An [AndStrategy] that evaluates to `true` only if all strategies return `true`.
+ */
+infix fun FlippingStrategy.and(other: FlippingStrategy): AndStrategy = when (this) {
+    is AndStrategy -> copy(strategies = strategies + other)
+    else -> AndStrategy(listOf(this, other))
+}
+
+/**
+ * Combines this strategy with [other] using logical OR.
+ *
+ * If this strategy is already an [OrStrategy], the [other] strategy is appended
+ * to its list, creating a flat structure instead of nesting.
+ *
+ * Example:
+ * ```kotlin
+ * val strategy = strategyA or strategyB or strategyC
+ * // Creates OrStrategy([a, b, c]) instead of OrStrategy([OrStrategy([a, b]), c])
+ * ```
+ *
+ * @param other The strategy to combine with.
+ * @return An [OrStrategy] that evaluates to `true` if any strategy returns `true`.
+ */
+infix fun FlippingStrategy.or(other: FlippingStrategy): OrStrategy = when (this) {
+    is OrStrategy -> copy(strategies = strategies + other)
+    else -> OrStrategy(listOf(this, other))
+}
+
+/**
+ * Negates this strategy.
+ *
+ * Example:
+ * ```kotlin
+ * val strategy = !alwaysTrueStrategy  // evaluates to false
+ * ```
+ *
+ * @return A [NotStrategy] that inverts the evaluation result.
+ */
+operator fun FlippingStrategy.not(): NotStrategy = NotStrategy(this)

--- a/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/strategy/CompositeFlippingStrategy.kt
+++ b/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/strategy/CompositeFlippingStrategy.kt
@@ -1,0 +1,82 @@
+package com.yonatankarp.ff4k.strategy
+
+import com.yonatankarp.ff4k.core.FeatureStore
+import com.yonatankarp.ff4k.core.FlippingExecutionContext
+import com.yonatankarp.ff4k.core.FlippingStrategy
+import kotlinx.serialization.Polymorphic
+import kotlinx.serialization.Serializable
+
+/**
+ * A composite strategy that evaluates to `true` only if **all** child strategies evaluate to `true`.
+ *
+ * Uses short-circuit evaluation: stops evaluating as soon as any strategy returns `false`.
+ *
+ * Note: An empty [strategies] list evaluates to `true` (vacuous truth).
+ *
+ * @property strategies The list of strategies to evaluate with logical AND.
+ * @see OrStrategy
+ * @see NotStrategy
+ */
+@Serializable
+data class AndStrategy(
+    val strategies: List<@Polymorphic FlippingStrategy>,
+    override val initParams: Map<String, String> = emptyMap(),
+) : FlippingStrategy {
+    override suspend fun evaluate(
+        featureId: String,
+        store: FeatureStore?,
+        context: FlippingExecutionContext,
+    ): Boolean {
+        for (strategy in strategies) {
+            if (strategy.evaluate(featureId, store, context).not()) return false
+        }
+        return true
+    }
+}
+
+/**
+ * A composite strategy that evaluates to `true` if **any** child strategy evaluates to `true`.
+ *
+ * Uses short-circuit evaluation: stops evaluating as soon as any strategy returns `true`.
+ *
+ * Note: An empty [strategies] list evaluates to `false`.
+ *
+ * @property strategies The list of strategies to evaluate with logical OR.
+ * @see AndStrategy
+ * @see NotStrategy
+ */
+@Serializable
+data class OrStrategy(
+    val strategies: List<@Polymorphic FlippingStrategy>,
+    override val initParams: Map<String, String> = emptyMap(),
+) : FlippingStrategy {
+    override suspend fun evaluate(
+        featureId: String,
+        store: FeatureStore?,
+        context: FlippingExecutionContext,
+    ): Boolean {
+        for (strategy in strategies) {
+            if (strategy.evaluate(featureId, store, context)) return true
+        }
+        return false
+    }
+}
+
+/**
+ * A composite strategy that negates the result of another strategy.
+ *
+ * @property strategy The strategy whose result will be negated.
+ * @see AndStrategy
+ * @see OrStrategy
+ */
+@Serializable
+data class NotStrategy(
+    val strategy: @Polymorphic FlippingStrategy,
+    override val initParams: Map<String, String> = emptyMap(),
+) : FlippingStrategy {
+    override suspend fun evaluate(
+        featureId: String,
+        store: FeatureStore?,
+        context: FlippingExecutionContext,
+    ): Boolean = strategy.evaluate(featureId, store, context).not()
+}

--- a/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/strategy/ConstantFlippingStrategy.kt
+++ b/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/strategy/ConstantFlippingStrategy.kt
@@ -1,0 +1,39 @@
+package com.yonatankarp.ff4k.strategy
+
+import com.yonatankarp.ff4k.core.FeatureStore
+import com.yonatankarp.ff4k.core.FlippingExecutionContext
+import com.yonatankarp.ff4k.core.FlippingStrategy
+import kotlinx.serialization.Serializable
+
+/**
+ * A strategy that always evaluates to `true`.
+ *
+ * Useful as a base case in composite strategies or for testing.
+ *
+ * @see AlwaysFalseFlippingStrategy
+ */
+@Serializable
+data class AlwaysTrueFlippingStrategy(override val initParams: Map<String, String> = emptyMap()) : FlippingStrategy {
+
+    override suspend fun evaluate(
+        featureId: String,
+        store: FeatureStore?,
+        context: FlippingExecutionContext,
+    ): Boolean = true
+}
+
+/**
+ * A strategy that always evaluates to `false`.
+ *
+ * Useful as a base case in composite strategies or for testing.
+ *
+ * @see AlwaysTrueFlippingStrategy
+ */
+@Serializable
+data class AlwaysFalseFlippingStrategy(override val initParams: Map<String, String> = emptyMap()) : FlippingStrategy {
+    override suspend fun evaluate(
+        featureId: String,
+        store: FeatureStore?,
+        context: FlippingExecutionContext,
+    ): Boolean = false
+}

--- a/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/FF4kStatsTest.kt
+++ b/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/FF4kStatsTest.kt
@@ -1,6 +1,7 @@
 package com.yonatankarp.ff4k
 
 import com.yonatankarp.ff4k.dsl.core.ff4k
+import com.yonatankarp.ff4k.dsl.feature.FeaturesBuilder
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.datatest.withData
 import io.kotest.matchers.collections.shouldBeEmpty
@@ -182,7 +183,7 @@ internal class FF4kStatsTest :
             withData(
                 nameFn = { it.description },
                 reportGenerationData,
-            ) { (description, featuresBlock, expectedContent) ->
+            ) { (_, featuresBlock, expectedContent) ->
                 // Given
                 val ff4k = ff4k {
                     features(featuresBlock)
@@ -395,19 +396,19 @@ internal class FF4kStatsTest :
 }
 private data class ReportTestData(
     val description: String,
-    val featuresBlock: com.yonatankarp.ff4k.dsl.feature.FeaturesBuilder.() -> Unit,
+    val featuresBlock: FeaturesBuilder.() -> Unit,
     val expectedContent: List<String>,
 )
 
 private data class FeatureFilterData(
     val description: String,
-    val featuresBlock: com.yonatankarp.ff4k.dsl.feature.FeaturesBuilder.() -> Unit,
+    val featuresBlock: FeaturesBuilder.() -> Unit,
     val expectedUids: List<String>,
 )
 
 private data class PermissionFilterData(
     val description: String,
-    val featuresBlock: com.yonatankarp.ff4k.dsl.feature.FeaturesBuilder.() -> Unit,
+    val featuresBlock: FeaturesBuilder.() -> Unit,
     val permission: String,
     val expectedUids: List<String>,
 )

--- a/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/core/FeatureTest.kt
+++ b/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/core/FeatureTest.kt
@@ -3,6 +3,7 @@ package com.yonatankarp.ff4k.core
 import com.yonatankarp.ff4k.property.PropertyInt
 import com.yonatankarp.ff4k.property.PropertyString
 import com.yonatankarp.ff4k.serialization.ff4kSerializersModule
+import com.yonatankarp.ff4k.strategy.AlwaysTrueFlippingStrategy
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.datatest.withData
@@ -195,18 +196,14 @@ internal class FeatureTest :
 
         test("displayStrategyClassName should return strategy class name when strategy exists") {
             // Given
-            class TestStrategy : FlippingStrategy {
-                override val initParams = emptyMap<String, String>()
-            }
-
-            val strategy = TestStrategy()
+            val strategy = AlwaysTrueFlippingStrategy()
             val feature = Feature(uid = FEATURE_UID, flippingStrategy = strategy)
 
             // When
             val className = feature.displayStrategyClassName
 
             // Then
-            className shouldBe "TestStrategy"
+            className shouldBe "AlwaysTrueFlippingStrategy"
         }
 
         test("getProperty should return property when it exists") {

--- a/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/core/FeaturesTest.kt
+++ b/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/core/FeaturesTest.kt
@@ -3,6 +3,7 @@ package com.yonatankarp.ff4k.core
 import com.yonatankarp.ff4k.exception.PropertyNotFoundException
 import com.yonatankarp.ff4k.property.PropertyInt
 import com.yonatankarp.ff4k.property.PropertyString
+import com.yonatankarp.ff4k.strategy.AlwaysTrueFlippingStrategy
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.datatest.withData
@@ -120,12 +121,9 @@ internal class FeaturesTest :
 
         test("hasFlippingStrategy should return true when strategy exists") {
             // Given
-            class TestStrategy : FlippingStrategy {
-                override val initParams = emptyMap<String, String>()
-            }
             val feature = Feature(
                 uid = FEATURE_UID,
-                flippingStrategy = TestStrategy(),
+                flippingStrategy = AlwaysTrueFlippingStrategy(),
             )
 
             // When

--- a/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/dsl/core/FF4kBuilderTest.kt
+++ b/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/dsl/core/FF4kBuilderTest.kt
@@ -6,6 +6,7 @@ import com.yonatankarp.ff4k.property.PropertyInt
 import com.yonatankarp.ff4k.property.PropertyString
 import com.yonatankarp.ff4k.store.InMemoryFeatureStore
 import com.yonatankarp.ff4k.store.InMemoryPropertyStore
+import com.yonatankarp.ff4k.strategy.AlwaysTrueFlippingStrategy
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.booleans.shouldBeFalse
 import io.kotest.matchers.booleans.shouldBeTrue
@@ -190,7 +191,7 @@ internal class FF4kBuilderTest :
 
         test("ff4k creates complete configuration with all options") {
             // Given
-            val strategy = TestStrategy()
+            val strategy = AlwaysTrueFlippingStrategy()
             val preBuiltFeature = Feature(FEATURE_LEGACY, isEnabled = false)
             val preBuiltProperty = PropertyInt(PROPERTY_PORT, VALUE_PORT)
 
@@ -291,9 +292,6 @@ internal class FF4kBuilderTest :
             ff4k.property<Int>(PROPERTY_MAX_RETRIES)?.value shouldBe VALUE_MAX_RETRIES
         }
     }) {
-    private class TestStrategy : FlippingStrategy {
-        override val initParams = emptyMap<String, String>()
-    }
 
     private companion object {
         private const val FEATURE_DARK_MODE = "dark-mode"

--- a/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/dsl/feature/FeatureBuilderTest.kt
+++ b/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/dsl/feature/FeatureBuilderTest.kt
@@ -1,8 +1,8 @@
 package com.yonatankarp.ff4k.dsl.feature
 
-import com.yonatankarp.ff4k.core.FlippingStrategy
 import com.yonatankarp.ff4k.property.PropertyInt
 import com.yonatankarp.ff4k.property.PropertyString
+import com.yonatankarp.ff4k.strategy.AlwaysTrueFlippingStrategy
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.booleans.shouldBeFalse
@@ -37,7 +37,7 @@ internal class FeatureBuilderTest :
 
         test("feature creates feature with all fields set") {
             // Given
-            val strategy = TestStrategy()
+            val strategy = AlwaysTrueFlippingStrategy()
 
             // When
             val feature = feature(FEATURE_UID) {
@@ -80,7 +80,7 @@ internal class FeatureBuilderTest :
 
         test("flippingStrategy property sets strategy") {
             // Given
-            val strategy = TestStrategy()
+            val strategy = AlwaysTrueFlippingStrategy()
 
             // When
             val feature = feature(FEATURE_UID) {
@@ -311,7 +311,7 @@ internal class FeatureBuilderTest :
 
         test("complex nested scenario with all features") {
             // Given
-            val strategy = TestStrategy()
+            val strategy = AlwaysTrueFlippingStrategy()
             val existingProp = PropertyString(
                 name = PROPERTY_EXTERNAL_CONFIG,
                 value = EXTERNAL_CONFIG_VALUE,
@@ -382,9 +382,6 @@ internal class FeatureBuilderTest :
             }
         }
     }) {
-    private class TestStrategy : FlippingStrategy {
-        override val initParams = emptyMap<String, String>()
-    }
 
     private companion object {
         // Feature constants

--- a/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/strategy/CompositeFlippingStrategyTest.kt
+++ b/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/strategy/CompositeFlippingStrategyTest.kt
@@ -1,0 +1,482 @@
+package com.yonatankarp.ff4k.strategy
+
+import com.yonatankarp.ff4k.core.FlippingExecutionContext
+import com.yonatankarp.ff4k.core.FlippingStrategy
+import com.yonatankarp.ff4k.serialization.FF4kJson
+import com.yonatankarp.ff4k.store.InMemoryFeatureStore
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.datatest.withData
+import io.kotest.matchers.booleans.shouldBeFalse
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.types.shouldBeInstanceOf
+import kotlinx.serialization.encodeToString
+
+internal class CompositeFlippingStrategyTest :
+    FunSpec({
+        context("test AndStrategy") {
+            withData(
+                nameFn = { it.description },
+                andStrategyCases,
+            ) { (_, left, right, expected) ->
+                // Given
+                val store = InMemoryFeatureStore()
+                val context = FlippingExecutionContext()
+
+                // When
+                val andStrategy = left and right
+
+                // Then
+                andStrategy.evaluate("test", store, context) shouldBe expected
+            }
+        }
+
+        test("test AndStrategy evaluates to true when no strategies supplied") {
+            // Given
+            val store = InMemoryFeatureStore()
+            val context = FlippingExecutionContext()
+            val andStrategy = AndStrategy(strategies = emptyList())
+
+            // When
+            val result = andStrategy.evaluate("test", store, context)
+
+            // Then
+            result.shouldBeTrue()
+        }
+
+        test("test OrStrategy evaluates to false when no strategies supplied") {
+            // Given
+            val store = InMemoryFeatureStore()
+            val context = FlippingExecutionContext()
+            val orStrategy = OrStrategy(strategies = emptyList())
+
+            // When
+            val result = orStrategy.evaluate("test", store, context)
+
+            // Then
+            result.shouldBeFalse()
+        }
+
+        context("test OrStrategy") {
+            withData(
+                nameFn = { it.description },
+                orStrategyCases,
+            ) { (_, left, right, expected) ->
+                // Given
+                val store = InMemoryFeatureStore()
+                val context = FlippingExecutionContext()
+
+                // When
+                val orStrategy = left or right
+
+                // Then
+                orStrategy.evaluate("test", store, context) shouldBe expected
+            }
+        }
+
+        context("test NotStrategy") {
+            withData(
+                nameFn = { it.description },
+                notStrategyCases,
+            ) { (_, operand, expected) ->
+                // Given
+                val store = InMemoryFeatureStore()
+                val context = FlippingExecutionContext()
+
+                // When
+                val notStrategy = !operand
+
+                // Then
+                notStrategy.evaluate("test", store, context) shouldBe expected
+            }
+        }
+
+        context("DSL flattening for AndStrategy") {
+            test("chaining 'and' creates flat list instead of nested structure") {
+                // Given
+                val a = AlwaysTrueFlippingStrategy()
+                val b = AlwaysFalseFlippingStrategy()
+                val c = AlwaysTrueFlippingStrategy()
+
+                // When
+                val result = a and b and c
+
+                // Then
+                result.strategies shouldHaveSize 3
+                result.strategies[0] shouldBe a
+                result.strategies[1] shouldBe b
+                result.strategies[2] shouldBe c
+            }
+
+            test("chaining multiple 'and' operations creates flat list") {
+                // Given
+                val a = AlwaysTrueFlippingStrategy()
+                val b = AlwaysTrueFlippingStrategy()
+                val c = AlwaysTrueFlippingStrategy()
+                val d = AlwaysTrueFlippingStrategy()
+                val e = AlwaysTrueFlippingStrategy()
+
+                // When
+                val result = a and b and c and d and e
+
+                // Then
+                result.strategies shouldHaveSize 5
+            }
+
+            test("'and' with non-AndStrategy creates new list") {
+                // Given
+                val a = AlwaysTrueFlippingStrategy()
+                val b = AlwaysFalseFlippingStrategy()
+
+                // When
+                val result = a and b
+
+                // Then
+                result.strategies shouldHaveSize 2
+            }
+        }
+
+        context("DSL flattening for OrStrategy") {
+            test("chaining 'or' creates flat list instead of nested structure") {
+                // Given
+                val a = AlwaysTrueFlippingStrategy()
+                val b = AlwaysFalseFlippingStrategy()
+                val c = AlwaysTrueFlippingStrategy()
+
+                // When
+                val result = a or b or c
+
+                // Then
+                result.strategies shouldHaveSize 3
+                result.strategies[0] shouldBe a
+                result.strategies[1] shouldBe b
+                result.strategies[2] shouldBe c
+            }
+
+            test("chaining multiple 'or' operations creates flat list") {
+                // Given
+                val a = AlwaysFalseFlippingStrategy()
+                val b = AlwaysFalseFlippingStrategy()
+                val c = AlwaysFalseFlippingStrategy()
+                val d = AlwaysFalseFlippingStrategy()
+                val e = AlwaysFalseFlippingStrategy()
+
+                // When
+                val result = a or b or c or d or e
+
+                // Then
+                result.strategies shouldHaveSize 5
+            }
+
+            test("'or' with non-OrStrategy creates new list") {
+                // Given
+                val a = AlwaysTrueFlippingStrategy()
+                val b = AlwaysFalseFlippingStrategy()
+
+                // When
+                val result = a or b
+
+                // Then
+                result.strategies shouldHaveSize 2
+            }
+        }
+
+        context("DSL does not flatten different strategy types") {
+            test("'and' after 'or' creates nested structure") {
+                // Given
+                val a = AlwaysTrueFlippingStrategy()
+                val b = AlwaysFalseFlippingStrategy()
+                val c = AlwaysTrueFlippingStrategy()
+
+                // When
+                val result = (a or b) and c
+
+                // Then
+                result.strategies shouldHaveSize 2
+                result.strategies[0].shouldBeInstanceOf<OrStrategy>()
+                result.strategies[1] shouldBe c
+            }
+
+            test("'or' after 'and' creates nested structure") {
+                // Given
+                val a = AlwaysTrueFlippingStrategy()
+                val b = AlwaysFalseFlippingStrategy()
+                val c = AlwaysTrueFlippingStrategy()
+
+                // When
+                val result = (a and b) or c
+
+                // Then
+                result.strategies shouldHaveSize 2
+                result.strategies[0].shouldBeInstanceOf<AndStrategy>()
+                result.strategies[1] shouldBe c
+            }
+        }
+
+        context("AndStrategy serialization") {
+            test("serializes to JSON with nested strategies") {
+                // Given
+                val strategy =
+                    AlwaysTrueFlippingStrategy() and AlwaysFalseFlippingStrategy()
+
+                // When
+                val json = FF4kJson.encodeToString(strategy)
+
+                // Then
+                json shouldContain "AlwaysTrueFlippingStrategy"
+                json shouldContain "AlwaysFalseFlippingStrategy"
+            }
+
+            test("round-trip serialization") {
+                // Given
+                val original =
+                    AlwaysTrueFlippingStrategy() and AlwaysFalseFlippingStrategy()
+
+                // When
+                val json = FF4kJson.encodeToString(original)
+                val deserialized = FF4kJson.decodeFromString<AndStrategy>(json)
+
+                // Then
+                deserialized shouldBe original
+            }
+
+            test("round-trip with nested AndStrategy") {
+                // Given
+                val original =
+                    AndStrategy(strategies = listOf(AlwaysTrueFlippingStrategy())) and AlwaysFalseFlippingStrategy()
+
+                // When
+                val json = FF4kJson.encodeToString(original)
+                val deserialized = FF4kJson.decodeFromString<AndStrategy>(json)
+
+                // Then
+                deserialized shouldBe original
+            }
+        }
+
+        context("OrStrategy serialization") {
+            test("serializes to JSON with nested strategies") {
+                // Given
+                val strategy =
+                    AlwaysTrueFlippingStrategy() or AlwaysFalseFlippingStrategy()
+
+                // When
+                val json = FF4kJson.encodeToString(strategy)
+
+                // Then
+                json shouldContain "AlwaysTrueFlippingStrategy"
+                json shouldContain "AlwaysFalseFlippingStrategy"
+            }
+
+            test("round-trip serialization") {
+                // Given
+                val original =
+                    AlwaysTrueFlippingStrategy() or AlwaysFalseFlippingStrategy()
+
+                // When
+                val json = FF4kJson.encodeToString(original)
+                val deserialized = FF4kJson.decodeFromString<OrStrategy>(json)
+
+                // Then
+                deserialized shouldBe original
+            }
+
+            test("round-trip with nested OrStrategy") {
+                // Given
+                val original =
+                    OrStrategy(strategies = listOf(AlwaysTrueFlippingStrategy())) or AlwaysFalseFlippingStrategy()
+
+                // When
+                val json = FF4kJson.encodeToString(original)
+                val deserialized = FF4kJson.decodeFromString<OrStrategy>(json)
+
+                // Then
+                deserialized shouldBe original
+            }
+        }
+
+        context("NotStrategy serialization") {
+            test("serializes to JSON with nested strategy") {
+                // Given
+                val strategy = AlwaysTrueFlippingStrategy().not()
+
+                // When
+                val json = FF4kJson.encodeToString(strategy)
+
+                // Then
+                json shouldContain "AlwaysTrueFlippingStrategy"
+            }
+
+            test("round-trip serialization") {
+                // Given
+                val original = AlwaysTrueFlippingStrategy().not()
+
+                // When
+                val json = FF4kJson.encodeToString(original)
+                val deserialized = FF4kJson.decodeFromString<NotStrategy>(json)
+
+                // Then
+                deserialized shouldBe original
+            }
+
+            test("round-trip with nested NotStrategy") {
+                // Given
+                val original =
+                    NotStrategy(strategy = AlwaysFalseFlippingStrategy().not())
+
+                // When
+                val json = FF4kJson.encodeToString(original)
+                val deserialized = FF4kJson.decodeFromString<NotStrategy>(json)
+
+                // Then
+                deserialized shouldBe original
+            }
+        }
+
+        context("complex composite strategy serialization") {
+            withData(
+                nameFn = { it.description },
+                complexStrategyCases,
+            ) { (_, strategy) ->
+                // When
+                val json =
+                    FF4kJson.encodeToString(strategy)
+                val deserialized =
+                    FF4kJson.decodeFromString<FlippingStrategy>(json)
+
+                // Then
+                deserialized shouldBe strategy
+            }
+        }
+    }) {
+    companion object {
+        private val andStrategyCases = listOf(
+            CompositeFlippingStrategyTestData(
+                description = "false AND false returns false",
+                left = AlwaysFalseFlippingStrategy(),
+                right = AlwaysFalseFlippingStrategy(),
+                expected = false,
+            ),
+            CompositeFlippingStrategyTestData(
+                description = "true AND false returns false",
+                left = AlwaysTrueFlippingStrategy(),
+                right = AlwaysFalseFlippingStrategy(),
+                expected = false,
+            ),
+            CompositeFlippingStrategyTestData(
+                description = "false AND true returns false",
+                left = AlwaysFalseFlippingStrategy(),
+                right = AlwaysTrueFlippingStrategy(),
+                expected = false,
+            ),
+            CompositeFlippingStrategyTestData(
+                description = "true AND true returns true",
+                left = AlwaysTrueFlippingStrategy(),
+                right = AlwaysTrueFlippingStrategy(),
+                expected = true,
+            ),
+        )
+
+        private val orStrategyCases = listOf(
+            CompositeFlippingStrategyTestData(
+                description = "false OR false returns false",
+                left = AlwaysFalseFlippingStrategy(),
+                right = AlwaysFalseFlippingStrategy(),
+                expected = false,
+            ),
+            CompositeFlippingStrategyTestData(
+                description = "true OR false returns true",
+                left = AlwaysTrueFlippingStrategy(),
+                right = AlwaysFalseFlippingStrategy(),
+                expected = true,
+            ),
+            CompositeFlippingStrategyTestData(
+                description = "false OR true returns true",
+                left = AlwaysFalseFlippingStrategy(),
+                right = AlwaysTrueFlippingStrategy(),
+                expected = true,
+            ),
+            CompositeFlippingStrategyTestData(
+                description = "true OR true returns true",
+                left = AlwaysTrueFlippingStrategy(),
+                right = AlwaysTrueFlippingStrategy(),
+                expected = true,
+            ),
+        )
+
+        private val notStrategyCases = listOf(
+            NotStrategyTestData(
+                description = "NOT false returns true",
+                operand = AlwaysFalseFlippingStrategy(),
+                expected = true,
+            ),
+            NotStrategyTestData(
+                description = "NOT true returns false",
+                operand = AlwaysTrueFlippingStrategy(),
+                expected = false,
+            ),
+        )
+
+        private val complexStrategyCases = listOf(
+            ComplexStrategyTestData(
+                description = "AND with OR children",
+                strategy = AndStrategy(
+                    strategies = listOf(
+                        AlwaysTrueFlippingStrategy() or AlwaysFalseFlippingStrategy(),
+                        AlwaysTrueFlippingStrategy(),
+                    ),
+                ),
+            ),
+            ComplexStrategyTestData(
+                description = "OR with AND children",
+                strategy = OrStrategy(
+                    strategies = listOf(
+                        AlwaysTrueFlippingStrategy() and AlwaysFalseFlippingStrategy(),
+                        AlwaysFalseFlippingStrategy(),
+                    ),
+                ),
+            ),
+            ComplexStrategyTestData(
+                description = "NOT with AND child",
+                strategy = NotStrategy(
+                    strategy = AlwaysTrueFlippingStrategy() and AlwaysTrueFlippingStrategy(),
+                ),
+            ),
+            ComplexStrategyTestData(
+                description = "NOT with OR child",
+                strategy = NotStrategy(
+                    strategy = AlwaysFalseFlippingStrategy() or AlwaysFalseFlippingStrategy(),
+                ),
+            ),
+            ComplexStrategyTestData(
+                description = "deeply nested composite",
+                strategy = AndStrategy(
+                    strategies = listOf(
+                        AlwaysFalseFlippingStrategy().not() or (AlwaysTrueFlippingStrategy() and AlwaysTrueFlippingStrategy()),
+                        AlwaysFalseFlippingStrategy().not(),
+                    ),
+                ),
+            ),
+        )
+    }
+}
+
+private data class CompositeFlippingStrategyTestData(
+    val description: String,
+    val left: FlippingStrategy,
+    val right: FlippingStrategy,
+    val expected: Boolean,
+)
+
+private data class NotStrategyTestData(
+    val description: String,
+    val operand: FlippingStrategy,
+    val expected: Boolean,
+)
+
+private data class ComplexStrategyTestData(
+    val description: String,
+    val strategy: FlippingStrategy,
+)


### PR DESCRIPTION
Introduce composite strategies that allow combining multiple flipping strategies using boolean logic. This enables complex feature flag conditions without custom strategy implementations.

New strategies:
- AndStrategy: Evaluates to true only if all child strategies are true
- OrStrategy: Evaluates to true if any child strategy is true
- NotStrategy: Negates the result of another strategy
- AlwaysTrueFlippingStrategy / AlwaysFalseFlippingStrategy: Constant strategies useful as base cases in composite expressions

DSL support via extension functions enables readable composition:
  val strategy = strategyA and strategyB or !strategyC

Also adds:
- AbstractFlippingStrategy base class for future strategy implementations
- FF4kJson: Pre-configured Json instance with FF4k serializers module

Closes #18

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added composite flipping strategies (And, Or, Not) and fluent composition extensions (and, or, not).
  * Added constant strategies (AlwaysTrue, AlwaysFalse).
  * Added a parameter-validation helper for strategies.

* **Chores**
  * Standardized JSON serialization across the library with a configured JSON instance (ignore unknown keys, pretty print) used for encoding/decoding and tests.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->