### PR TITLE
feat(dsl): add DSL builder for FlippingExecutionContext

### DIFF
--- a/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/core/FlippingExecutionContext.kt
+++ b/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/core/FlippingExecutionContext.kt
@@ -31,7 +31,7 @@ import kotlin.coroutines.CoroutineContext
  * @author Yonatan Karp-Rudin (@yonatankarp)
  */
 data class FlippingExecutionContext(
-    @PublishedApi internal val values: MutableMap<String, Any?> = mutableMapOf(),
+    @PublishedApi internal val values: Map<String, Any> = emptyMap(),
 ) : CoroutineContext.Element {
     /**
      * Key for retrieving [FlippingExecutionContext] from a [CoroutineContext].
@@ -45,7 +45,7 @@ data class FlippingExecutionContext(
      *
      * @param pairs Initial parameters to populate the context
      */
-    constructor(vararg pairs: Pair<String, Any?>) : this(mutableMapOf(*pairs))
+    constructor(vararg pairs: Pair<String, Any>) : this(mapOf(*pairs))
 
     /**
      * Retrieves a value from the context with runtime type checking.
@@ -73,14 +73,14 @@ data class FlippingExecutionContext(
     }
 
     /**
-     * Stores a value in the context.
+     * Combines this context with another, returning a new context containing all entries from both.
      *
-     * @param key the key under which to store the value
-     * @param value the value to store
+     * If both contexts contain the same key, the value from [other] takes precedence.
+     *
+     * @param other The context to combine with this one
+     * @return A new [FlippingExecutionContext] containing entries from both contexts
      */
-    operator fun <T> set(key: String, value: T) {
-        values[key] = value as Any?
-    }
+    operator fun plus(other: FlippingExecutionContext): FlippingExecutionContext = copy(values = (values + other.values))
 
     /**
      * Checks if the context contains a value for the given key.

--- a/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/core/FlippingExecutionContexts.kt
+++ b/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/core/FlippingExecutionContexts.kt
@@ -1,7 +1,7 @@
 package com.yonatankarp.ff4k.core
 
+import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.withContext
-import kotlin.coroutines.coroutineContext
 
 // ============================================================================
 // Immutable Builder Extensions
@@ -22,7 +22,7 @@ import kotlin.coroutines.coroutineContext
  * @param value The parameter value
  * @return A new [FlippingExecutionContext] with the added parameter
  */
-fun FlippingExecutionContext.withParameter(key: String, value: Any?): FlippingExecutionContext = FlippingExecutionContext((values + (key to value)).toMutableMap())
+fun FlippingExecutionContext.withParameter(key: String, value: Any): FlippingExecutionContext = FlippingExecutionContext((values + (key to value)))
 
 /**
  * Creates a new context with additional parameters.
@@ -41,7 +41,7 @@ fun FlippingExecutionContext.withParameter(key: String, value: Any?): FlippingEx
  * @param pairs The parameters to add
  * @return A new [FlippingExecutionContext] with the added parameters
  */
-fun FlippingExecutionContext.withParameters(vararg pairs: Pair<String, Any?>): FlippingExecutionContext = FlippingExecutionContext((values + pairs.toMap()).toMutableMap())
+fun FlippingExecutionContext.withParameters(vararg pairs: Pair<String, Any>): FlippingExecutionContext = FlippingExecutionContext((values + pairs.toMap()))
 
 /**
  * Merges this context with another, with the other context's values taking precedence.
@@ -119,7 +119,7 @@ suspend inline fun <T> withFlippingContext(
  * @return The result of the block
  */
 suspend inline fun <T> withFlippingParameters(
-    vararg parameters: Pair<String, Any?>,
+    vararg parameters: Pair<String, Any>,
     crossinline block: suspend () -> T,
 ): T {
     val current = currentFlippingContext()
@@ -143,4 +143,4 @@ suspend inline fun <T> withFlippingParameters(
  *
  * @return The current [FlippingExecutionContext], or an empty context if none is set
  */
-suspend fun currentFlippingContext(): FlippingExecutionContext = coroutineContext[FlippingExecutionContext] ?: FlippingExecutionContext()
+suspend fun currentFlippingContext(): FlippingExecutionContext = currentCoroutineContext()[FlippingExecutionContext] ?: FlippingExecutionContext()

--- a/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/dsl/core/FlippingExecutionContextBuilder.kt
+++ b/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/dsl/core/FlippingExecutionContextBuilder.kt
@@ -1,0 +1,100 @@
+package com.yonatankarp.ff4k.dsl.core
+
+import com.yonatankarp.ff4k.core.FlippingExecutionContext
+
+/**
+ * A DSL builder for constructing [FlippingExecutionContext] instances.
+ *
+ * Provides a type-safe, expressive way to define context parameters using
+ * Kotlin DSL syntax.
+ *
+ * Example usage:
+ * ```kotlin
+ * val ctx = context {
+ *     "userId" to "user-123"
+ *     "region" to "EU"
+ *     this["tier"] = "premium"
+ * }
+ * ```
+ *
+ * @see context
+ */
+@FF4kDsl
+class FlippingExecutionContextBuilder {
+    private val values = mutableMapOf<String, Any>()
+
+    /**
+     * Adds a key-value pair to the context using infix notation.
+     *
+     * Example:
+     * ```kotlin
+     * context {
+     *     "userId" to "user-123"
+     * }
+     * ```
+     *
+     * @param value The value to associate with this key
+     */
+    infix fun String.to(value: Any) {
+        values[this] = value
+    }
+
+    /**
+     * Adds a key-value pair to the context using indexed access notation.
+     *
+     * Example:
+     * ```kotlin
+     * context {
+     *     this["userId"] = "user-123"
+     * }
+     * ```
+     *
+     * @param key The parameter key
+     * @param value The value to associate with the key
+     */
+    operator fun set(key: String, value: Any) {
+        values[key] = value
+    }
+
+    /**
+     * Adds all entries from the given map to the context.
+     *
+     * @param map The map of parameters to add
+     */
+    fun putAll(map: Map<String, Any>) {
+        values.putAll(map)
+    }
+
+    /**
+     * Adds all given key-value pairs to the context.
+     *
+     * @param pairs The parameters to add
+     */
+    fun putAll(vararg pairs: Pair<String, Any>) {
+        values.putAll(pairs)
+    }
+
+    /**
+     * Builds and returns the [FlippingExecutionContext] with all configured parameters.
+     *
+     * @return A new [FlippingExecutionContext] containing all added parameters
+     */
+    fun build(): FlippingExecutionContext = FlippingExecutionContext(values.toMap())
+}
+
+/**
+ * Creates a [FlippingExecutionContext] using a DSL builder.
+ *
+ * Example:
+ * ```kotlin
+ * val ctx = context {
+ *     "userId" to "user-123"
+ *     "region" to "EU"
+ *     "tier" to "premium"
+ * }
+ * ```
+ *
+ * @param block The builder block to configure the context
+ * @return A new [FlippingExecutionContext] with the configured parameters
+ */
+fun context(block: FlippingExecutionContextBuilder.() -> Unit): FlippingExecutionContext = FlippingExecutionContextBuilder().apply(block).build()

--- a/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/core/FlippingExecutionContextTest.kt
+++ b/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/core/FlippingExecutionContextTest.kt
@@ -16,10 +16,12 @@ internal class FlippingExecutionContextTest :
 
         test("should store and retrieve values with correct types") {
             // Given
-            val context = FlippingExecutionContext()
-            context["userId"] = 123
-            context["userName"] = "Alice"
-            context["isActive"] = true
+            val values = mapOf(
+                "userId" to 123,
+                "userName" to "Alice",
+                "isActive" to true,
+            )
+            val context = FlippingExecutionContext(values)
 
             // When
             val userId = context.get<Int>("userId")
@@ -45,8 +47,8 @@ internal class FlippingExecutionContextTest :
 
         test("should throw when type mismatch occurs") {
             // Given
-            val context = FlippingExecutionContext()
-            context["userId"] = 123
+            val values = mapOf("userId" to 123)
+            val context = FlippingExecutionContext(values)
 
             // When / Then
             shouldThrow<IllegalStateException> {
@@ -66,8 +68,8 @@ internal class FlippingExecutionContextTest :
 
         test("should not throw when required key exists") {
             // Given
-            val context = FlippingExecutionContext()
-            context["key"] = "value"
+            val values = mapOf("key" to "value")
+            val context = FlippingExecutionContext(values)
 
             // When
             val result = context.get<String>("key", required = true)
@@ -78,8 +80,8 @@ internal class FlippingExecutionContextTest :
 
         test("contains operator should return true for existing keys") {
             // Given
-            val context = FlippingExecutionContext()
-            context["userId"] = 123
+            val values = mapOf("userId" to 123)
+            val context = FlippingExecutionContext(values)
 
             // When
             val contains = "userId" in context
@@ -112,8 +114,8 @@ internal class FlippingExecutionContextTest :
 
         test("isEmpty should return false after adding values") {
             // Given
-            val context = FlippingExecutionContext()
-            context["key"] = "value"
+            val values = mapOf("key" to "value")
+            val context = FlippingExecutionContext(values)
 
             // When
             val isEmpty = context.isEmpty
@@ -122,26 +124,12 @@ internal class FlippingExecutionContextTest :
             isEmpty.shouldBeFalse()
         }
 
-        test("should handle null values correctly") {
-            // Given
-            val context = FlippingExecutionContext()
-            context["nullableValue"] = null
-
-            // When
-            val value = context.get<String?>("nullableValue")
-            val contains = "nullableValue" in context
-
-            // Then
-            value shouldBe null
-            contains.shouldBeTrue()
-        }
-
         test("should work with data class as value in context") {
             // Given
             data class User(val id: Int, val name: String)
-            val context = FlippingExecutionContext()
             val user = User(1, "Alice")
-            context["user"] = user
+            val values = mapOf("user" to user)
+            val context = FlippingExecutionContext(values)
 
             // When
             val result = context.get<User>("user")
@@ -152,12 +140,14 @@ internal class FlippingExecutionContextTest :
 
         test("should support multiple types in same context") {
             // Given
-            val context = FlippingExecutionContext()
-            context["string"] = "text"
-            context["int"] = 42
-            context["double"] = 3.14
-            context["boolean"] = true
-            context["list"] = listOf(1, 2, 3)
+            val values = mapOf(
+                "string" to "text",
+                "int" to 42,
+                "double" to 3.14,
+                "boolean" to true,
+                "list" to listOf(1, 2, 3),
+            )
+            val context = FlippingExecutionContext(values)
 
             // When
             val string = context.get<String>("string")
@@ -172,5 +162,62 @@ internal class FlippingExecutionContextTest :
             double shouldBe 3.14
             boolean shouldBe true
             list shouldBe listOf(1, 2, 3)
+        }
+
+        test("plus operator should combine two contexts") {
+            // Given
+            val context1 = FlippingExecutionContext("userId" to "user-123", "region" to "EU")
+            val context2 = FlippingExecutionContext("tier" to "premium", "enabled" to true)
+
+            // When
+            val combined = context1 + context2
+
+            // Then
+            combined.get<String>("userId") shouldBe "user-123"
+            combined.get<String>("region") shouldBe "EU"
+            combined.get<String>("tier") shouldBe "premium"
+            combined.get<Boolean>("enabled") shouldBe true
+        }
+
+        test("plus operator should give precedence to right context for duplicate keys") {
+            // Given
+            val context1 = FlippingExecutionContext("tier" to "free", "region" to "US")
+            val context2 = FlippingExecutionContext("tier" to "premium")
+
+            // When
+            val combined = context1 + context2
+
+            // Then
+            combined.get<String>("tier") shouldBe "premium"
+            combined.get<String>("region") shouldBe "US"
+        }
+
+        test("plus operator should not modify original contexts") {
+            // Given
+            val context1 = FlippingExecutionContext("key1" to "value1")
+            val context2 = FlippingExecutionContext("key2" to "value2")
+
+            // When
+            val combined = context1 + context2
+
+            // Then
+            ("key2" in context1).shouldBeFalse()
+            ("key1" in context2).shouldBeFalse()
+            ("key1" in combined).shouldBeTrue()
+            ("key2" in combined).shouldBeTrue()
+        }
+
+        test("plus operator with empty context should return equivalent context") {
+            // Given
+            val context = FlippingExecutionContext("userId" to "user-123")
+            val empty = FlippingExecutionContext()
+
+            // When
+            val result1 = context + empty
+            val result2 = empty + context
+
+            // Then
+            result1.get<String>("userId") shouldBe "user-123"
+            result2.get<String>("userId") shouldBe "user-123"
         }
     })

--- a/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/dsl/core/FlippingExecutionContextBuilderTest.kt
+++ b/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/dsl/core/FlippingExecutionContextBuilderTest.kt
@@ -1,0 +1,157 @@
+package com.yonatankarp.ff4k.dsl.core
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Tests for FlippingExecutionContextBuilder DSL.
+ *
+ * @author Yonatan Karp-Rudin
+ */
+internal class FlippingExecutionContextBuilderTest :
+    FunSpec({
+
+        test("context function should create empty context when block is empty") {
+            // When
+            val ctx = context { }
+
+            // Then
+            ctx.isEmpty.shouldBeTrue()
+        }
+
+        test("context function should support infix to notation") {
+            // When
+            val ctx = context {
+                "userId" to "user-123"
+                "region" to "EU"
+            }
+
+            // Then
+            ctx.get<String>("userId") shouldBe "user-123"
+            ctx.get<String>("region") shouldBe "EU"
+        }
+
+        test("context function should support indexed access notation") {
+            // When
+            val ctx = context {
+                this["userId"] = "user-456"
+                this["tier"] = "premium"
+            }
+
+            // Then
+            ctx.get<String>("userId") shouldBe "user-456"
+            ctx.get<String>("tier") shouldBe "premium"
+        }
+
+        test("context function should support mixed notation") {
+            // When
+            val ctx = context {
+                "userId" to "user-789"
+                this["region"] = "US"
+                "tier" to "enterprise"
+            }
+
+            // Then
+            ctx.get<String>("userId") shouldBe "user-789"
+            ctx.get<String>("region") shouldBe "US"
+            ctx.get<String>("tier") shouldBe "enterprise"
+        }
+
+        test("context function should support putAll with map") {
+            // Given
+            val params = mapOf("userId" to "user-123", "region" to "APAC")
+
+            // When
+            val ctx = context {
+                putAll(params)
+            }
+
+            // Then
+            ctx.get<String>("userId") shouldBe "user-123"
+            ctx.get<String>("region") shouldBe "APAC"
+        }
+
+        test("context function should support putAll with vararg pairs") {
+            // When
+            val ctx = context {
+                putAll(
+                    Pair("userId", "user-123"),
+                    Pair("region", "EU"),
+                    Pair("tier", "free"),
+                )
+            }
+
+            // Then
+            ctx.get<String>("userId") shouldBe "user-123"
+            ctx.get<String>("region") shouldBe "EU"
+            ctx.get<String>("tier") shouldBe "free"
+        }
+
+        test("context function should support various value types") {
+            // When
+            val ctx = context {
+                "string" to "text"
+                "int" to 42
+                "double" to 3.14
+                "boolean" to true
+                "list" to listOf(1, 2, 3)
+            }
+
+            // Then
+            ctx.get<String>("string") shouldBe "text"
+            ctx.get<Int>("int") shouldBe 42
+            ctx.get<Double>("double") shouldBe 3.14
+            ctx.get<Boolean>("boolean") shouldBe true
+            ctx.get<List<Int>>("list") shouldBe listOf(1, 2, 3)
+        }
+
+        test("context function should override earlier values with same key") {
+            // When
+            val ctx = context {
+                "tier" to "free"
+                "tier" to "premium"
+            }
+
+            // Then
+            ctx.get<String>("tier") shouldBe "premium"
+        }
+
+        test("builder should work with custom data classes") {
+            // Given
+            data class User(val id: Int, val name: String)
+            val user = User(1, "Alice")
+
+            // When
+            val ctx = context {
+                "user" to user
+            }
+
+            // Then
+            ctx.get<User>("user") shouldBe user
+        }
+
+        test("builder set operator should override infix to value") {
+            // When
+            val ctx = context {
+                "key" to "first"
+                this["key"] = "second"
+            }
+
+            // Then
+            ctx.get<String>("key") shouldBe "second"
+        }
+
+        test("putAll should merge with existing values") {
+            // When
+            val ctx = context {
+                "existing" to "value"
+                putAll(Pair("new1", "value1"), Pair("new2", "value2"))
+            }
+
+            // Then
+            ctx.get<String>("existing") shouldBe "value"
+            ctx.get<String>("new1") shouldBe "value1"
+            ctx.get<String>("new2") shouldBe "value2"
+        }
+    })


### PR DESCRIPTION

## Summary

This change introduces a Kotlin DSL builder for creating FlippingExecutionContext instances in a more expressive and type-safe way. Instead of using the vararg constructor or manual map construction, users can now use the `context { }` builder function with infix `to` notation for a cleaner API.

The `plus` operator has been added to FlippingExecutionContext to allow combining two contexts, with values from the right-hand context taking precedence for duplicate keys. This enables composing contexts from multiple sources without mutating the original instances.

All public APIs have been documented with KDocs including usage examples. The implementation follows an immutable design pattern rather than the mutable approach originally specified in issue #19, as immutability provides better thread-safety and works naturally with Kotlin coroutines.


## Motivation

<!-- Why is this change needed? Link to related issue if applicable -->

Closes #19


## Changes

<!-- What does this PR do? List the main changes -->

-

## Testing

<!-- How did you test these changes? -->

- [x] Unit tests added/updated
- [x] Tested on JVM
- [x] Tested on Android
- [x] Tested on iOS

## Checklist

- [x] My code follows the project's code style (`./gradlew spotlessCheck` passes)
- [x] I have added tests that prove my fix/feature works
- [x] All tests pass (`./gradlew check`)
- [x] I have updated documentation if needed
- [ ] I marked all checkboxes without reading


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a DSL builder for creating execution contexts with an expressive, type-safe syntax using the `context` function.
  * Added support for combining contexts using the `+` operator.

* **Breaking Changes**
  * Execution contexts are now immutable after creation; parameters must be set during initialization.
  * Parameter values must be non-nullable.
  * Removed direct parameter assignment; use context builders or the `plus` operator instead.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->