### PR TITLE
chore(build): remove androidVariantsToPublish from publish config

### DIFF
--- a/build-logic/src/main/kotlin/ff4k.publish.gradle.kts
+++ b/build-logic/src/main/kotlin/ff4k.publish.gradle.kts
@@ -11,7 +11,6 @@ mavenPublishing {
         KotlinMultiplatform(
             javadocJar = JavadocJar.Dokka("dokkaGeneratePublicationHtml"),
             sourcesJar = true,
-            androidVariantsToPublish = listOf("release")
         )
     )
 


### PR DESCRIPTION
Remove the explicit androidVariantsToPublish parameter due to deprecation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Android library publishing configuration to exclude the release variant from package distribution.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->