### PR TITLE
refactor(strategy): simplify FlippingStrategy interface

### DIFF
--- a/ff4k-contract-test/src/commonMain/kotlin/com/yonatankarp/ff4k/test/contract/strategy/FlippingStrategyContractTest.kt
+++ b/ff4k-contract-test/src/commonMain/kotlin/com/yonatankarp/ff4k/test/contract/strategy/FlippingStrategyContractTest.kt
@@ -46,17 +46,6 @@ abstract class FlippingStrategyContractTest : FunSpec() {
     protected abstract fun expectedJsonForSampleParams(): String
 
     init {
-        test("should store init params") {
-            // Given
-            val initParams = sampleInitParams()
-
-            // When
-            val strategy = createStrategy(initParams)
-
-            // Then
-            strategy.initParams shouldBe initParams
-        }
-
         test("should evaluate to true when context matches strategy criteria") {
             // Given
             val initParams = sampleInitParams()
@@ -109,20 +98,6 @@ abstract class FlippingStrategyContractTest : FunSpec() {
 
             // Then
             actualJson shouldBe expectedJson
-        }
-
-        test("should deserialize from json") {
-            // Given
-            val initParams = sampleInitParams()
-            val strategy = createStrategy(initParams)
-            val jsonString = expectedJsonForSampleParams()
-
-            // When
-            val serializer = PolymorphicSerializer(FlippingStrategy::class)
-            val deserialized = FF4kJson.decodeFromString(serializer, jsonString)
-
-            // Then
-            deserialized.initParams shouldBe strategy.initParams
         }
     }
 

--- a/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/core/FlippingStrategy.kt
+++ b/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/core/FlippingStrategy.kt
@@ -44,17 +44,6 @@ package com.yonatankarp.ff4k.core
  */
 interface FlippingStrategy {
     /**
-     * Configuration parameters for this strategy.
-     *
-     * These parameters are provided during strategy initialization and define the behavior
-     * of the strategy. For example:
-     * - A percentage-based strategy might have `{"percentage": "25"}`
-     * - A region-based strategy might have `{"regions": "US,EU,APAC"}`
-     * - A time-based strategy might have `{"startTime": "09:00", "endTime": "17:00"}`
-     */
-    val initParams: Map<String, String>
-
-    /**
      * Evaluates whether the feature should be enabled based on the execution context.
      *
      * This method contains the core decision logic for the strategy. It examines the
@@ -71,14 +60,4 @@ interface FlippingStrategy {
         store: FeatureStore?,
         context: FlippingExecutionContext,
     ): Boolean
-
-    /**
-     * Asserts that a required parameter exists in [initParams].
-     *
-     * @param paramName The name of the required parameter.
-     * @throws IllegalArgumentException if the parameter is not present.
-     */
-    fun assertRequiredParameter(paramName: String) {
-        require(paramName in initParams.keys) { "Parameter '$paramName' is required for this FlippingStrategy" }
-    }
 }

--- a/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/strategy/CompositeFlippingStrategy.kt
+++ b/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/strategy/CompositeFlippingStrategy.kt
@@ -4,6 +4,7 @@ import com.yonatankarp.ff4k.core.FeatureStore
 import com.yonatankarp.ff4k.core.FlippingExecutionContext
 import com.yonatankarp.ff4k.core.FlippingStrategy
 import kotlinx.serialization.Polymorphic
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 /**
@@ -18,9 +19,9 @@ import kotlinx.serialization.Serializable
  * @see NotStrategy
  */
 @Serializable
+@SerialName("and")
 data class AndStrategy(
     val strategies: List<@Polymorphic FlippingStrategy>,
-    override val initParams: Map<String, String> = emptyMap(),
 ) : FlippingStrategy {
     override suspend fun evaluate(
         featureId: String,
@@ -46,9 +47,9 @@ data class AndStrategy(
  * @see NotStrategy
  */
 @Serializable
+@SerialName("or")
 data class OrStrategy(
     val strategies: List<@Polymorphic FlippingStrategy>,
-    override val initParams: Map<String, String> = emptyMap(),
 ) : FlippingStrategy {
     override suspend fun evaluate(
         featureId: String,
@@ -70,9 +71,9 @@ data class OrStrategy(
  * @see OrStrategy
  */
 @Serializable
+@SerialName("not")
 data class NotStrategy(
     val strategy: @Polymorphic FlippingStrategy,
-    override val initParams: Map<String, String> = emptyMap(),
 ) : FlippingStrategy {
     override suspend fun evaluate(
         featureId: String,

--- a/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/strategy/ConstantFlippingStrategy.kt
+++ b/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/strategy/ConstantFlippingStrategy.kt
@@ -3,6 +3,7 @@ package com.yonatankarp.ff4k.strategy
 import com.yonatankarp.ff4k.core.FeatureStore
 import com.yonatankarp.ff4k.core.FlippingExecutionContext
 import com.yonatankarp.ff4k.core.FlippingStrategy
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 /**
@@ -13,7 +14,8 @@ import kotlinx.serialization.Serializable
  * @see AlwaysFalseFlippingStrategy
  */
 @Serializable
-data class AlwaysTrueFlippingStrategy(override val initParams: Map<String, String> = emptyMap()) : FlippingStrategy {
+@SerialName("alwaysTrue")
+data object AlwaysTrueFlippingStrategy : FlippingStrategy {
 
     override suspend fun evaluate(
         featureId: String,
@@ -30,7 +32,8 @@ data class AlwaysTrueFlippingStrategy(override val initParams: Map<String, Strin
  * @see AlwaysTrueFlippingStrategy
  */
 @Serializable
-data class AlwaysFalseFlippingStrategy(override val initParams: Map<String, String> = emptyMap()) : FlippingStrategy {
+@SerialName("alwaysFalse")
+data object AlwaysFalseFlippingStrategy : FlippingStrategy {
     override suspend fun evaluate(
         featureId: String,
         store: FeatureStore?,

--- a/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/FF4kExtensionsTest.kt
+++ b/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/FF4kExtensionsTest.kt
@@ -397,8 +397,6 @@ internal class FF4kExtensionsTest :
      * Simple flipping strategy that checks if the context contains a specific user ID.
      */
     private class UserIdStrategy(private val allowedUserId: String) : FlippingStrategy {
-        override val initParams: Map<String, String> = mapOf("allowedUserId" to allowedUserId)
-
         override suspend fun evaluate(
             featureId: String,
             store: FeatureStore?,

--- a/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/core/FeatureTest.kt
+++ b/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/core/FeatureTest.kt
@@ -196,7 +196,7 @@ internal class FeatureTest :
 
         test("displayStrategyClassName should return strategy class name when strategy exists") {
             // Given
-            val strategy = AlwaysTrueFlippingStrategy()
+            val strategy = AlwaysTrueFlippingStrategy
             val feature = Feature(uid = FEATURE_UID, flippingStrategy = strategy)
 
             // When

--- a/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/core/FeaturesTest.kt
+++ b/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/core/FeaturesTest.kt
@@ -123,7 +123,7 @@ internal class FeaturesTest :
             // Given
             val feature = Feature(
                 uid = FEATURE_UID,
-                flippingStrategy = AlwaysTrueFlippingStrategy(),
+                flippingStrategy = AlwaysTrueFlippingStrategy,
             )
 
             // When

--- a/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/dsl/core/FF4kBuilderTest.kt
+++ b/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/dsl/core/FF4kBuilderTest.kt
@@ -191,7 +191,7 @@ internal class FF4kBuilderTest :
 
         test("ff4k creates complete configuration with all options") {
             // Given
-            val strategy = AlwaysTrueFlippingStrategy()
+            val strategy = AlwaysTrueFlippingStrategy
             val preBuiltFeature = Feature(FEATURE_LEGACY, isEnabled = false)
             val preBuiltProperty = PropertyInt(PROPERTY_PORT, VALUE_PORT)
 

--- a/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/dsl/feature/FeatureBuilderTest.kt
+++ b/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/dsl/feature/FeatureBuilderTest.kt
@@ -37,7 +37,7 @@ internal class FeatureBuilderTest :
 
         test("feature creates feature with all fields set") {
             // Given
-            val strategy = AlwaysTrueFlippingStrategy()
+            val strategy = AlwaysTrueFlippingStrategy
 
             // When
             val feature = feature(FEATURE_UID) {
@@ -80,7 +80,7 @@ internal class FeatureBuilderTest :
 
         test("flippingStrategy property sets strategy") {
             // Given
-            val strategy = AlwaysTrueFlippingStrategy()
+            val strategy = AlwaysTrueFlippingStrategy
 
             // When
             val feature = feature(FEATURE_UID) {
@@ -311,7 +311,7 @@ internal class FeatureBuilderTest :
 
         test("complex nested scenario with all features") {
             // Given
-            val strategy = AlwaysTrueFlippingStrategy()
+            val strategy = AlwaysTrueFlippingStrategy
             val existingProp = PropertyString(
                 name = PROPERTY_EXTERNAL_CONFIG,
                 value = EXTERNAL_CONFIG_VALUE,

--- a/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/strategy/CompositeFlippingStrategyTest.kt
+++ b/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/strategy/CompositeFlippingStrategyTest.kt
@@ -96,9 +96,9 @@ internal class CompositeFlippingStrategyTest :
         context("DSL flattening for AndStrategy") {
             test("chaining 'and' creates flat list instead of nested structure") {
                 // Given
-                val a = AlwaysTrueFlippingStrategy()
-                val b = AlwaysFalseFlippingStrategy()
-                val c = AlwaysTrueFlippingStrategy()
+                val a = AlwaysTrueFlippingStrategy
+                val b = AlwaysFalseFlippingStrategy
+                val c = AlwaysTrueFlippingStrategy
 
                 // When
                 val result = a and b and c
@@ -112,11 +112,11 @@ internal class CompositeFlippingStrategyTest :
 
             test("chaining multiple 'and' operations creates flat list") {
                 // Given
-                val a = AlwaysTrueFlippingStrategy()
-                val b = AlwaysTrueFlippingStrategy()
-                val c = AlwaysTrueFlippingStrategy()
-                val d = AlwaysTrueFlippingStrategy()
-                val e = AlwaysTrueFlippingStrategy()
+                val a = AlwaysTrueFlippingStrategy
+                val b = AlwaysTrueFlippingStrategy
+                val c = AlwaysTrueFlippingStrategy
+                val d = AlwaysTrueFlippingStrategy
+                val e = AlwaysTrueFlippingStrategy
 
                 // When
                 val result = a and b and c and d and e
@@ -127,8 +127,8 @@ internal class CompositeFlippingStrategyTest :
 
             test("'and' with non-AndStrategy creates new list") {
                 // Given
-                val a = AlwaysTrueFlippingStrategy()
-                val b = AlwaysFalseFlippingStrategy()
+                val a = AlwaysTrueFlippingStrategy
+                val b = AlwaysFalseFlippingStrategy
 
                 // When
                 val result = a and b
@@ -141,9 +141,9 @@ internal class CompositeFlippingStrategyTest :
         context("DSL flattening for OrStrategy") {
             test("chaining 'or' creates flat list instead of nested structure") {
                 // Given
-                val a = AlwaysTrueFlippingStrategy()
-                val b = AlwaysFalseFlippingStrategy()
-                val c = AlwaysTrueFlippingStrategy()
+                val a = AlwaysTrueFlippingStrategy
+                val b = AlwaysFalseFlippingStrategy
+                val c = AlwaysTrueFlippingStrategy
 
                 // When
                 val result = a or b or c
@@ -157,11 +157,11 @@ internal class CompositeFlippingStrategyTest :
 
             test("chaining multiple 'or' operations creates flat list") {
                 // Given
-                val a = AlwaysFalseFlippingStrategy()
-                val b = AlwaysFalseFlippingStrategy()
-                val c = AlwaysFalseFlippingStrategy()
-                val d = AlwaysFalseFlippingStrategy()
-                val e = AlwaysFalseFlippingStrategy()
+                val a = AlwaysFalseFlippingStrategy
+                val b = AlwaysFalseFlippingStrategy
+                val c = AlwaysFalseFlippingStrategy
+                val d = AlwaysFalseFlippingStrategy
+                val e = AlwaysFalseFlippingStrategy
 
                 // When
                 val result = a or b or c or d or e
@@ -172,8 +172,8 @@ internal class CompositeFlippingStrategyTest :
 
             test("'or' with non-OrStrategy creates new list") {
                 // Given
-                val a = AlwaysTrueFlippingStrategy()
-                val b = AlwaysFalseFlippingStrategy()
+                val a = AlwaysTrueFlippingStrategy
+                val b = AlwaysFalseFlippingStrategy
 
                 // When
                 val result = a or b
@@ -186,9 +186,9 @@ internal class CompositeFlippingStrategyTest :
         context("DSL does not flatten different strategy types") {
             test("'and' after 'or' creates nested structure") {
                 // Given
-                val a = AlwaysTrueFlippingStrategy()
-                val b = AlwaysFalseFlippingStrategy()
-                val c = AlwaysTrueFlippingStrategy()
+                val a = AlwaysTrueFlippingStrategy
+                val b = AlwaysFalseFlippingStrategy
+                val c = AlwaysTrueFlippingStrategy
 
                 // When
                 val result = (a or b) and c
@@ -201,9 +201,9 @@ internal class CompositeFlippingStrategyTest :
 
             test("'or' after 'and' creates nested structure") {
                 // Given
-                val a = AlwaysTrueFlippingStrategy()
-                val b = AlwaysFalseFlippingStrategy()
-                val c = AlwaysTrueFlippingStrategy()
+                val a = AlwaysTrueFlippingStrategy
+                val b = AlwaysFalseFlippingStrategy
+                val c = AlwaysTrueFlippingStrategy
 
                 // When
                 val result = (a and b) or c
@@ -219,24 +219,24 @@ internal class CompositeFlippingStrategyTest :
             test("serializes to JSON with nested strategies") {
                 // Given
                 val strategy =
-                    AlwaysTrueFlippingStrategy() and AlwaysFalseFlippingStrategy()
+                    AlwaysTrueFlippingStrategy and AlwaysFalseFlippingStrategy
 
                 // When
                 val json = FF4kJson.encodeToString(strategy)
 
                 // Then
-                json shouldContain "AlwaysTrueFlippingStrategy"
-                json shouldContain "AlwaysFalseFlippingStrategy"
+                json shouldContain "alwaysTrue"
+                json shouldContain "alwaysFalse"
             }
 
             test("round-trip serialization") {
                 // Given
                 val original =
-                    AlwaysTrueFlippingStrategy() and AlwaysFalseFlippingStrategy()
+                    AlwaysTrueFlippingStrategy and AlwaysFalseFlippingStrategy
 
                 // When
-                val json = FF4kJson.encodeToString(original)
-                val deserialized = FF4kJson.decodeFromString<AndStrategy>(json)
+                val json = FF4kJson.encodeToString<FlippingStrategy>(original)
+                val deserialized = FF4kJson.decodeFromString<FlippingStrategy>(json)
 
                 // Then
                 deserialized shouldBe original
@@ -245,11 +245,11 @@ internal class CompositeFlippingStrategyTest :
             test("round-trip with nested AndStrategy") {
                 // Given
                 val original =
-                    AndStrategy(strategies = listOf(AlwaysTrueFlippingStrategy())) and AlwaysFalseFlippingStrategy()
+                    AndStrategy(strategies = listOf(AlwaysTrueFlippingStrategy)) and AlwaysFalseFlippingStrategy
 
                 // When
-                val json = FF4kJson.encodeToString(original)
-                val deserialized = FF4kJson.decodeFromString<AndStrategy>(json)
+                val json = FF4kJson.encodeToString<FlippingStrategy>(original)
+                val deserialized = FF4kJson.decodeFromString<FlippingStrategy>(json)
 
                 // Then
                 deserialized shouldBe original
@@ -260,24 +260,24 @@ internal class CompositeFlippingStrategyTest :
             test("serializes to JSON with nested strategies") {
                 // Given
                 val strategy =
-                    AlwaysTrueFlippingStrategy() or AlwaysFalseFlippingStrategy()
+                    AlwaysTrueFlippingStrategy or AlwaysFalseFlippingStrategy
 
                 // When
                 val json = FF4kJson.encodeToString(strategy)
 
                 // Then
-                json shouldContain "AlwaysTrueFlippingStrategy"
-                json shouldContain "AlwaysFalseFlippingStrategy"
+                json shouldContain "alwaysTrue"
+                json shouldContain "alwaysFalse"
             }
 
             test("round-trip serialization") {
                 // Given
                 val original =
-                    AlwaysTrueFlippingStrategy() or AlwaysFalseFlippingStrategy()
+                    AlwaysTrueFlippingStrategy or AlwaysFalseFlippingStrategy
 
                 // When
-                val json = FF4kJson.encodeToString(original)
-                val deserialized = FF4kJson.decodeFromString<OrStrategy>(json)
+                val json = FF4kJson.encodeToString<FlippingStrategy>(original)
+                val deserialized = FF4kJson.decodeFromString<FlippingStrategy>(json)
 
                 // Then
                 deserialized shouldBe original
@@ -286,11 +286,11 @@ internal class CompositeFlippingStrategyTest :
             test("round-trip with nested OrStrategy") {
                 // Given
                 val original =
-                    OrStrategy(strategies = listOf(AlwaysTrueFlippingStrategy())) or AlwaysFalseFlippingStrategy()
+                    OrStrategy(strategies = listOf(AlwaysTrueFlippingStrategy)) or AlwaysFalseFlippingStrategy
 
                 // When
-                val json = FF4kJson.encodeToString(original)
-                val deserialized = FF4kJson.decodeFromString<OrStrategy>(json)
+                val json = FF4kJson.encodeToString<FlippingStrategy>(original)
+                val deserialized = FF4kJson.decodeFromString<FlippingStrategy>(json)
 
                 // Then
                 deserialized shouldBe original
@@ -300,22 +300,22 @@ internal class CompositeFlippingStrategyTest :
         context("NotStrategy serialization") {
             test("serializes to JSON with nested strategy") {
                 // Given
-                val strategy = AlwaysTrueFlippingStrategy().not()
+                val strategy = AlwaysTrueFlippingStrategy.not()
 
                 // When
                 val json = FF4kJson.encodeToString(strategy)
 
                 // Then
-                json shouldContain "AlwaysTrueFlippingStrategy"
+                json shouldContain "alwaysTrue"
             }
 
             test("round-trip serialization") {
                 // Given
-                val original = AlwaysTrueFlippingStrategy().not()
+                val original = AlwaysTrueFlippingStrategy.not()
 
                 // When
-                val json = FF4kJson.encodeToString(original)
-                val deserialized = FF4kJson.decodeFromString<NotStrategy>(json)
+                val json = FF4kJson.encodeToString<FlippingStrategy>(original)
+                val deserialized = FF4kJson.decodeFromString<FlippingStrategy>(json)
 
                 // Then
                 deserialized shouldBe original
@@ -324,11 +324,11 @@ internal class CompositeFlippingStrategyTest :
             test("round-trip with nested NotStrategy") {
                 // Given
                 val original =
-                    NotStrategy(strategy = AlwaysFalseFlippingStrategy().not())
+                    NotStrategy(strategy = AlwaysFalseFlippingStrategy.not())
 
                 // When
-                val json = FF4kJson.encodeToString(original)
-                val deserialized = FF4kJson.decodeFromString<NotStrategy>(json)
+                val json = FF4kJson.encodeToString<FlippingStrategy>(original)
+                val deserialized = FF4kJson.decodeFromString<FlippingStrategy>(json)
 
                 // Then
                 deserialized shouldBe original
@@ -342,7 +342,7 @@ internal class CompositeFlippingStrategyTest :
             ) { (_, strategy) ->
                 // When
                 val json =
-                    FF4kJson.encodeToString(strategy)
+                    FF4kJson.encodeToString<FlippingStrategy>(strategy)
                 val deserialized =
                     FF4kJson.decodeFromString<FlippingStrategy>(json)
 
@@ -355,26 +355,26 @@ internal class CompositeFlippingStrategyTest :
         private val andStrategyCases = listOf(
             CompositeFlippingStrategyTestData(
                 description = "false AND false returns false",
-                left = AlwaysFalseFlippingStrategy(),
-                right = AlwaysFalseFlippingStrategy(),
+                left = AlwaysFalseFlippingStrategy,
+                right = AlwaysFalseFlippingStrategy,
                 expected = false,
             ),
             CompositeFlippingStrategyTestData(
                 description = "true AND false returns false",
-                left = AlwaysTrueFlippingStrategy(),
-                right = AlwaysFalseFlippingStrategy(),
+                left = AlwaysTrueFlippingStrategy,
+                right = AlwaysFalseFlippingStrategy,
                 expected = false,
             ),
             CompositeFlippingStrategyTestData(
                 description = "false AND true returns false",
-                left = AlwaysFalseFlippingStrategy(),
-                right = AlwaysTrueFlippingStrategy(),
+                left = AlwaysFalseFlippingStrategy,
+                right = AlwaysTrueFlippingStrategy,
                 expected = false,
             ),
             CompositeFlippingStrategyTestData(
                 description = "true AND true returns true",
-                left = AlwaysTrueFlippingStrategy(),
-                right = AlwaysTrueFlippingStrategy(),
+                left = AlwaysTrueFlippingStrategy,
+                right = AlwaysTrueFlippingStrategy,
                 expected = true,
             ),
         )
@@ -382,26 +382,26 @@ internal class CompositeFlippingStrategyTest :
         private val orStrategyCases = listOf(
             CompositeFlippingStrategyTestData(
                 description = "false OR false returns false",
-                left = AlwaysFalseFlippingStrategy(),
-                right = AlwaysFalseFlippingStrategy(),
+                left = AlwaysFalseFlippingStrategy,
+                right = AlwaysFalseFlippingStrategy,
                 expected = false,
             ),
             CompositeFlippingStrategyTestData(
                 description = "true OR false returns true",
-                left = AlwaysTrueFlippingStrategy(),
-                right = AlwaysFalseFlippingStrategy(),
+                left = AlwaysTrueFlippingStrategy,
+                right = AlwaysFalseFlippingStrategy,
                 expected = true,
             ),
             CompositeFlippingStrategyTestData(
                 description = "false OR true returns true",
-                left = AlwaysFalseFlippingStrategy(),
-                right = AlwaysTrueFlippingStrategy(),
+                left = AlwaysFalseFlippingStrategy,
+                right = AlwaysTrueFlippingStrategy,
                 expected = true,
             ),
             CompositeFlippingStrategyTestData(
                 description = "true OR true returns true",
-                left = AlwaysTrueFlippingStrategy(),
-                right = AlwaysTrueFlippingStrategy(),
+                left = AlwaysTrueFlippingStrategy,
+                right = AlwaysTrueFlippingStrategy,
                 expected = true,
             ),
         )
@@ -409,12 +409,12 @@ internal class CompositeFlippingStrategyTest :
         private val notStrategyCases = listOf(
             NotStrategyTestData(
                 description = "NOT false returns true",
-                operand = AlwaysFalseFlippingStrategy(),
+                operand = AlwaysFalseFlippingStrategy,
                 expected = true,
             ),
             NotStrategyTestData(
                 description = "NOT true returns false",
-                operand = AlwaysTrueFlippingStrategy(),
+                operand = AlwaysTrueFlippingStrategy,
                 expected = false,
             ),
         )
@@ -424,8 +424,8 @@ internal class CompositeFlippingStrategyTest :
                 description = "AND with OR children",
                 strategy = AndStrategy(
                     strategies = listOf(
-                        AlwaysTrueFlippingStrategy() or AlwaysFalseFlippingStrategy(),
-                        AlwaysTrueFlippingStrategy(),
+                        AlwaysTrueFlippingStrategy or AlwaysFalseFlippingStrategy,
+                        AlwaysTrueFlippingStrategy,
                     ),
                 ),
             ),
@@ -433,29 +433,29 @@ internal class CompositeFlippingStrategyTest :
                 description = "OR with AND children",
                 strategy = OrStrategy(
                     strategies = listOf(
-                        AlwaysTrueFlippingStrategy() and AlwaysFalseFlippingStrategy(),
-                        AlwaysFalseFlippingStrategy(),
+                        AlwaysTrueFlippingStrategy and AlwaysFalseFlippingStrategy,
+                        AlwaysFalseFlippingStrategy,
                     ),
                 ),
             ),
             ComplexStrategyTestData(
                 description = "NOT with AND child",
                 strategy = NotStrategy(
-                    strategy = AlwaysTrueFlippingStrategy() and AlwaysTrueFlippingStrategy(),
+                    strategy = AlwaysTrueFlippingStrategy and AlwaysTrueFlippingStrategy,
                 ),
             ),
             ComplexStrategyTestData(
                 description = "NOT with OR child",
                 strategy = NotStrategy(
-                    strategy = AlwaysFalseFlippingStrategy() or AlwaysFalseFlippingStrategy(),
+                    strategy = AlwaysFalseFlippingStrategy or AlwaysFalseFlippingStrategy,
                 ),
             ),
             ComplexStrategyTestData(
                 description = "deeply nested composite",
                 strategy = AndStrategy(
                     strategies = listOf(
-                        AlwaysFalseFlippingStrategy().not() or (AlwaysTrueFlippingStrategy() and AlwaysTrueFlippingStrategy()),
-                        AlwaysFalseFlippingStrategy().not(),
+                        AlwaysFalseFlippingStrategy.not() or (AlwaysTrueFlippingStrategy and AlwaysTrueFlippingStrategy),
+                        AlwaysFalseFlippingStrategy.not(),
                     ),
                 ),
             ),


### PR DESCRIPTION


## Summary

Simplify the `FlippingStrategy` interface and remove redundant additional contract fields

## Motivation

This simplification makes strategies easier to implement and use while maintaining full serialization support through explicit @SerialName annotations.

## Changes

- Remove initParams from FlippingStrategy interface (not needed for core functionality)
- Remove assertRequiredParameter helper method
- Convert AlwaysTrueFlippingStrategy and AlwaysFalseFlippingStrategy to data objects
- Add @SerialName annotations to all strategy classes for cleaner JSON serialization
- Update tests to use data object syntax and correct SerialName values
- Remove initParams-related tests from FlippingStrategyContractTest

This simplification makes strategies easier to implement and use while maintaining full serialization support through explicit @SerialName annotations.

## Testing

<!-- How did you test these changes? -->

- [x] Unit tests added/updated
- [x] Tested on JVM
- [x] Tested on Android
- [x] Tested on iOS

## Checklist

- [x] My code follows the project's code style (`./gradlew spotlessCheck` passes)
- [x] I have added tests that prove my fix/feature works
- [x] All tests pass (`./gradlew check`)
- [x] I have updated documentation if needed
- [ ] I marked all checkboxes without reading


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Simplified the FlippingStrategy interface by removing unnecessary parameter-related functionality
  * Converted constant strategies to singleton pattern for improved memory efficiency and simplified usage
  * Enhanced serialization naming for clearer strategy identification in serialized data

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->