### PR TITLE
feat(strategy): add allow list and deny list strategies

### DIFF
--- a/docs/strategies.md
+++ b/docs/strategies.md
@@ -63,6 +63,37 @@ val context = FlippingExecutionContext(ContextKeys.USER_ID to currentUserId)
 ff4k.check("beta-feature", context)
 ```
 
+#### AllowListStrategy
+
+Enables a feature only for specific users. All other users will have the feature disabled.
+
+Requires `ContextKeys.USER_ID` in the execution context.
+
+```kotlin
+feature("vip-feature") {
+    allowListStrategy {
+        +"user-123"
+        +"user-456"
+        add("user-789")
+    }
+}
+```
+
+#### DenyListStrategy
+
+Disables a feature for specific users. All other users will have the feature enabled.
+
+Requires `ContextKeys.USER_ID` in the execution context.
+
+```kotlin
+feature("new-ui") {
+    denyListStrategy {
+        +"problematic-user-1"
+        +"problematic-user-2"
+    }
+}
+```
+
 ### Composite Strategies
 
 Combine multiple strategies using logical operators.

--- a/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/dsl/strategy/StrategyDsl.kt
+++ b/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/dsl/strategy/StrategyDsl.kt
@@ -1,6 +1,9 @@
 package com.yonatankarp.ff4k.dsl.strategy
 
+import com.yonatankarp.ff4k.dsl.core.FF4kDsl
 import com.yonatankarp.ff4k.dsl.feature.FeatureBuilder
+import com.yonatankarp.ff4k.strategy.AllowListStrategy
+import com.yonatankarp.ff4k.strategy.DenyListStrategy
 import com.yonatankarp.ff4k.strategy.PonderationStrategy
 import com.yonatankarp.ff4k.strategy.UserPonderationStrategy
 
@@ -92,4 +95,108 @@ fun FeatureBuilder.userPonderationStrategy(weight: Double) {
  */
 fun FeatureBuilder.userPonderationStrategy(weight: Int) {
     flippingStrategy = UserPonderationStrategy(weight)
+}
+
+/**
+ * Configures an [AllowListStrategy] for this feature.
+ *
+ * Only users whose ID is in the allow list will have the feature enabled.
+ * Requires `userId` to be set in the [com.yonatankarp.ff4k.core.FlippingExecutionContext].
+ *
+ * ## Example
+ *
+ * ```kotlin
+ * feature("vip-feature") {
+ *     allowListStrategy {
+ *         +"user-123"
+ *         +"user-456"
+ *         add("user-789")
+ *     }
+ * }
+ * ```
+ *
+ * @param block A DSL block to configure the list of allowed user IDs.
+ * @see denyListStrategy for the inverse behavior
+ */
+fun FeatureBuilder.allowListStrategy(block: ListBuilder.() -> Unit) {
+    val list = ListBuilder().apply(block).build()
+    flippingStrategy = AllowListStrategy(list)
+}
+
+/**
+ * Configures a [DenyListStrategy] for this feature.
+ *
+ * Users whose ID is in the deny list will have the feature disabled;
+ * all other users will have it enabled. Requires `userId` to be set in the
+ * [com.yonatankarp.ff4k.core.FlippingExecutionContext].
+ *
+ * ## Example
+ *
+ * ```kotlin
+ * feature("new-ui") {
+ *     denyListStrategy {
+ *         +"problematic-user-1"
+ *         +"problematic-user-2"
+ *     }
+ * }
+ * ```
+ *
+ * @param block A DSL block to configure the list of denied user IDs.
+ * @see allowListStrategy for the inverse behavior
+ */
+fun FeatureBuilder.denyListStrategy(block: ListBuilder.() -> Unit) {
+    val list = ListBuilder().apply(block).build()
+    flippingStrategy = DenyListStrategy(list)
+}
+
+/**
+ * DSL builder for constructing a set of identifiers used by list-based strategies.
+ *
+ * Provides multiple ways to add identifiers:
+ * - Unary plus operator: `+"identifier"`
+ * - [add] function: `add("identifier")`
+ * - [addAll] function: `addAll("id1", "id2", "id3")`
+ *
+ * @see allowListStrategy
+ * @see denyListStrategy
+ */
+@FF4kDsl
+class ListBuilder {
+    private val identifiers = mutableSetOf<String>()
+
+    /**
+     * Adds this string as an identifier to the list.
+     *
+     * ## Example
+     *
+     * ```kotlin
+     * allowListStrategy {
+     *     +"user-123"
+     *     +"user-456"
+     * }
+     * ```
+     */
+    operator fun String.unaryPlus() {
+        identifiers.add(this)
+    }
+
+    /**
+     * Adds an identifier to the list.
+     *
+     * @param identifier The identifier to add.
+     */
+    fun add(identifier: String) {
+        identifiers.add(identifier)
+    }
+
+    /**
+     * Adds multiple identifiers to the list.
+     *
+     * @param identifiers The identifiers to add.
+     */
+    fun addAll(vararg identifiers: String) {
+        this.identifiers.addAll(identifiers)
+    }
+
+    internal fun build(): Set<String> = identifiers.toSet()
 }

--- a/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/serialization/FF4kSerializersModule.kt
+++ b/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/serialization/FF4kSerializersModule.kt
@@ -17,9 +17,11 @@ import com.yonatankarp.ff4k.property.PropertyLogLevel
 import com.yonatankarp.ff4k.property.PropertyLong
 import com.yonatankarp.ff4k.property.PropertyShort
 import com.yonatankarp.ff4k.property.PropertyString
+import com.yonatankarp.ff4k.strategy.AllowListStrategy
 import com.yonatankarp.ff4k.strategy.AlwaysFalseFlippingStrategy
 import com.yonatankarp.ff4k.strategy.AlwaysTrueFlippingStrategy
 import com.yonatankarp.ff4k.strategy.AndStrategy
+import com.yonatankarp.ff4k.strategy.DenyListStrategy
 import com.yonatankarp.ff4k.strategy.NotStrategy
 import com.yonatankarp.ff4k.strategy.OrStrategy
 import com.yonatankarp.ff4k.strategy.PonderationStrategy
@@ -55,6 +57,8 @@ val ff4kSerializersModule = SerializersModule {
         subclass(AlwaysFalseFlippingStrategy::class, AlwaysFalseFlippingStrategy.serializer())
         subclass(PonderationStrategy::class, PonderationStrategy.serializer())
         subclass(UserPonderationStrategy::class, UserPonderationStrategy.serializer())
+        subclass(AllowListStrategy::class, AllowListStrategy.serializer())
+        subclass(DenyListStrategy::class, DenyListStrategy.serializer())
     }
 } + humanReadableSerializerModule
 

--- a/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/strategy/AllowListStrategy.kt
+++ b/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/strategy/AllowListStrategy.kt
@@ -1,0 +1,33 @@
+package com.yonatankarp.ff4k.strategy
+
+import com.yonatankarp.ff4k.core.ContextKeys
+import com.yonatankarp.ff4k.core.FeatureStore
+import com.yonatankarp.ff4k.core.FlippingExecutionContext
+import com.yonatankarp.ff4k.core.FlippingStrategy
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * A strategy that enables a feature only for users in an allowed list.
+ *
+ * Requires [ContextKeys.USER_ID] to be set in the [FlippingExecutionContext].
+ * Returns `false` if no user ID is present or the list is empty.
+ *
+ * @property allowedList The set of user IDs for whom the feature is enabled.
+ */
+@Serializable
+@SerialName("allowList")
+data class AllowListStrategy(
+    val allowedList: Set<String>,
+) : FlippingStrategy {
+    override suspend fun evaluate(
+        featureId: String,
+        store: FeatureStore?,
+        context: FlippingExecutionContext,
+    ): Boolean {
+        if (allowedList.isEmpty()) return false
+
+        val userId = context.get<String>(ContextKeys.USER_ID) ?: return false
+        return userId in allowedList
+    }
+}

--- a/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/strategy/DenyListStrategy.kt
+++ b/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/strategy/DenyListStrategy.kt
@@ -1,0 +1,34 @@
+package com.yonatankarp.ff4k.strategy
+
+import com.yonatankarp.ff4k.core.ContextKeys
+import com.yonatankarp.ff4k.core.FeatureStore
+import com.yonatankarp.ff4k.core.FlippingExecutionContext
+import com.yonatankarp.ff4k.core.FlippingStrategy
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * A strategy that disables a feature for users in a deny list.
+ *
+ * Requires [ContextKeys.USER_ID] to be set in the [FlippingExecutionContext].
+ * Returns `true` if no user ID is present (allow by default) or if the user is not in the deny list.
+ *
+ * @property denyList The set of user IDs for whom the feature is disabled.
+ */
+@Serializable
+@SerialName("denyList")
+data class DenyListStrategy(
+    val denyList: Set<String>,
+) : FlippingStrategy {
+    override suspend fun evaluate(
+        featureId: String,
+        store: FeatureStore?,
+        context: FlippingExecutionContext,
+    ): Boolean {
+        if (denyList.isEmpty()) return true
+
+        val userId = context.get<String>(ContextKeys.USER_ID) ?: return true
+
+        return userId !in denyList
+    }
+}

--- a/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/dsl/strategy/StrategyDslTest.kt
+++ b/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/dsl/strategy/StrategyDslTest.kt
@@ -1,9 +1,12 @@
 package com.yonatankarp.ff4k.dsl.strategy
 
 import com.yonatankarp.ff4k.dsl.feature.feature
+import com.yonatankarp.ff4k.strategy.AllowListStrategy
+import com.yonatankarp.ff4k.strategy.DenyListStrategy
 import com.yonatankarp.ff4k.strategy.PonderationStrategy
 import com.yonatankarp.ff4k.strategy.UserPonderationStrategy
 import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
 
@@ -44,5 +47,139 @@ internal class StrategyDslTest :
 
             feature.flippingStrategy.shouldBeInstanceOf<UserPonderationStrategy>()
             (feature.flippingStrategy as UserPonderationStrategy).weight shouldBe 0.5
+        }
+
+        context("allowListStrategy") {
+            test("sets AllowListStrategy with unary plus operator") {
+                val feature = feature("test") {
+                    allowListStrategy {
+                        +"user-1"
+                        +"user-2"
+                    }
+                }
+
+                feature.flippingStrategy.shouldBeInstanceOf<AllowListStrategy>()
+                (feature.flippingStrategy as AllowListStrategy).allowedList shouldContainExactlyInAnyOrder
+                    listOf("user-1", "user-2")
+            }
+
+            test("sets AllowListStrategy with add function") {
+                val feature = feature("test") {
+                    allowListStrategy {
+                        add("user-1")
+                        add("user-2")
+                    }
+                }
+
+                feature.flippingStrategy.shouldBeInstanceOf<AllowListStrategy>()
+                (feature.flippingStrategy as AllowListStrategy).allowedList shouldContainExactlyInAnyOrder
+                    listOf("user-1", "user-2")
+            }
+
+            test("sets AllowListStrategy with addAll function") {
+                val feature = feature("test") {
+                    allowListStrategy {
+                        addAll("user-1", "user-2", "user-3")
+                    }
+                }
+
+                feature.flippingStrategy.shouldBeInstanceOf<AllowListStrategy>()
+                (feature.flippingStrategy as AllowListStrategy).allowedList shouldContainExactlyInAnyOrder
+                    listOf("user-1", "user-2", "user-3")
+            }
+
+            test("sets AllowListStrategy with mixed methods") {
+                val feature = feature("test") {
+                    allowListStrategy {
+                        +"user-1"
+                        add("user-2")
+                        addAll("user-3", "user-4")
+                    }
+                }
+
+                feature.flippingStrategy.shouldBeInstanceOf<AllowListStrategy>()
+                (feature.flippingStrategy as AllowListStrategy).allowedList shouldContainExactlyInAnyOrder
+                    listOf("user-1", "user-2", "user-3", "user-4")
+            }
+
+            test("deduplicates entries") {
+                val feature = feature("test") {
+                    allowListStrategy {
+                        +"user-1"
+                        +"user-1"
+                        add("user-1")
+                    }
+                }
+
+                feature.flippingStrategy.shouldBeInstanceOf<AllowListStrategy>()
+                (feature.flippingStrategy as AllowListStrategy).allowedList shouldBe setOf("user-1")
+            }
+        }
+
+        context("denyListStrategy") {
+            test("sets DenyListStrategy with unary plus operator") {
+                val feature = feature("test") {
+                    denyListStrategy {
+                        +"user-1"
+                        +"user-2"
+                    }
+                }
+
+                feature.flippingStrategy.shouldBeInstanceOf<DenyListStrategy>()
+                (feature.flippingStrategy as DenyListStrategy).denyList shouldContainExactlyInAnyOrder
+                    listOf("user-1", "user-2")
+            }
+
+            test("sets DenyListStrategy with add function") {
+                val feature = feature("test") {
+                    denyListStrategy {
+                        add("user-1")
+                        add("user-2")
+                    }
+                }
+
+                feature.flippingStrategy.shouldBeInstanceOf<DenyListStrategy>()
+                (feature.flippingStrategy as DenyListStrategy).denyList shouldContainExactlyInAnyOrder
+                    listOf("user-1", "user-2")
+            }
+
+            test("sets DenyListStrategy with addAll function") {
+                val feature = feature("test") {
+                    denyListStrategy {
+                        addAll("user-1", "user-2", "user-3")
+                    }
+                }
+
+                feature.flippingStrategy.shouldBeInstanceOf<DenyListStrategy>()
+                (feature.flippingStrategy as DenyListStrategy).denyList shouldContainExactlyInAnyOrder
+                    listOf("user-1", "user-2", "user-3")
+            }
+
+            test("sets DenyListStrategy with mixed methods") {
+                val feature = feature("test") {
+                    denyListStrategy {
+                        +"user-1"
+                        add("user-2")
+                        addAll("user-3", "user-4")
+                    }
+                }
+
+                feature.flippingStrategy.shouldBeInstanceOf<DenyListStrategy>()
+                (feature.flippingStrategy as DenyListStrategy).denyList shouldContainExactlyInAnyOrder
+                    listOf("user-1", "user-2", "user-3", "user-4")
+            }
+
+            test("deduplicates entries") {
+                val feature = feature("test") {
+                    denyListStrategy {
+                        +"user-1"
+                        +"user-1"
+                        add("user-1")
+                    }
+                }
+
+                feature.flippingStrategy.shouldBeInstanceOf<DenyListStrategy>()
+                (feature.flippingStrategy as DenyListStrategy).denyList shouldBe setOf("user-1")
+            }
         }
     })

--- a/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/strategy/AllowListStrategyTest.kt
+++ b/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/strategy/AllowListStrategyTest.kt
@@ -1,0 +1,104 @@
+package com.yonatankarp.ff4k.strategy
+
+import com.yonatankarp.ff4k.core.ContextKeys
+import com.yonatankarp.ff4k.core.FlippingExecutionContext
+import com.yonatankarp.ff4k.core.FlippingStrategy
+import com.yonatankarp.ff4k.serialization.FF4kJson
+import com.yonatankarp.ff4k.store.InMemoryFeatureStore
+import com.yonatankarp.ff4k.test.contract.strategy.FlippingStrategyContractTest
+import io.kotest.matchers.booleans.shouldBeFalse
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.shouldBe
+import kotlinx.serialization.encodeToString
+
+internal class AllowListStrategyTest :
+    FlippingStrategyContractTest({
+
+        context("evaluate") {
+            test("returns false when allow list is empty") {
+                // Given
+                val strategy = AllowListStrategy(emptySet())
+                val store = InMemoryFeatureStore()
+                val context = FlippingExecutionContext(ContextKeys.USER_ID to "Alice")
+
+                // When
+                val result = strategy.evaluate("test", store, context)
+
+                // Then
+                result.shouldBeFalse()
+            }
+
+            test("returns false when user ID is missing from context") {
+                // Given
+                val strategy = AllowListStrategy(setOf("Alice", "Bob"))
+                val store = InMemoryFeatureStore()
+                val context = FlippingExecutionContext()
+
+                // When
+                val result = strategy.evaluate("test", store, context)
+
+                // Then
+                result.shouldBeFalse()
+            }
+
+            test("returns true only for users in the allow list") {
+                // Given
+                val strategy = AllowListStrategy(setOf("Alice", "Charlie"))
+                val store = InMemoryFeatureStore()
+
+                // When / Then
+                strategy.evaluate("test", store, FlippingExecutionContext(ContextKeys.USER_ID to "Alice")).shouldBeTrue()
+                strategy.evaluate("test", store, FlippingExecutionContext(ContextKeys.USER_ID to "Charlie")).shouldBeTrue()
+                strategy.evaluate("test", store, FlippingExecutionContext(ContextKeys.USER_ID to "Bob")).shouldBeFalse()
+                strategy.evaluate("test", store, FlippingExecutionContext(ContextKeys.USER_ID to "David")).shouldBeFalse()
+            }
+
+            test("handles null feature store") {
+                // Given
+                val strategy = AllowListStrategy(setOf("Alice"))
+                val context = FlippingExecutionContext(ContextKeys.USER_ID to "Alice")
+
+                // When
+                val result = strategy.evaluate("test", null, context)
+
+                // Then
+                result.shouldBeTrue()
+            }
+        }
+
+        context("serialization") {
+            test("round-trip serialization preserves strategy") {
+                // Given
+                val strategy = AllowListStrategy(setOf("Alice", "Bob", "Charlie"))
+
+                // When
+                val json = FF4kJson.encodeToString<FlippingStrategy>(strategy)
+                val deserialized = FF4kJson.decodeFromString<FlippingStrategy>(json)
+
+                // Then
+                deserialized shouldBe strategy
+            }
+
+            test("round-trip serialization preserves empty list") {
+                // Given
+                val strategy = AllowListStrategy(emptySet())
+
+                // When
+                val json = FF4kJson.encodeToString<FlippingStrategy>(strategy)
+                val deserialized = FF4kJson.decodeFromString<FlippingStrategy>(json)
+
+                // Then
+                deserialized shouldBe strategy
+            }
+        }
+    }) {
+
+    override fun createStrategy(): FlippingStrategy = AllowListStrategy(setOf("Alice"))
+
+    override fun contextThatShouldPass(): FlippingExecutionContext = FlippingExecutionContext(ContextKeys.USER_ID to "Alice")
+
+    override fun contextThatShouldFail(): FlippingExecutionContext = FlippingExecutionContext(ContextKeys.USER_ID to "Bob")
+
+    override fun expectedJsonForSampleParams(): String = // language=json
+        """{"type": "allowList","allowedList": ["Alice"]}"""
+}

--- a/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/strategy/DenyListStrategyTest.kt
+++ b/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/strategy/DenyListStrategyTest.kt
@@ -1,0 +1,104 @@
+package com.yonatankarp.ff4k.strategy
+
+import com.yonatankarp.ff4k.core.ContextKeys
+import com.yonatankarp.ff4k.core.FlippingExecutionContext
+import com.yonatankarp.ff4k.core.FlippingStrategy
+import com.yonatankarp.ff4k.serialization.FF4kJson
+import com.yonatankarp.ff4k.store.InMemoryFeatureStore
+import com.yonatankarp.ff4k.test.contract.strategy.FlippingStrategyContractTest
+import io.kotest.matchers.booleans.shouldBeFalse
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.shouldBe
+import kotlinx.serialization.encodeToString
+
+internal class DenyListStrategyTest :
+    FlippingStrategyContractTest({
+
+        context("evaluate") {
+            test("returns true when deny list is empty") {
+                // Given
+                val strategy = DenyListStrategy(emptySet())
+                val store = InMemoryFeatureStore()
+                val context = FlippingExecutionContext(ContextKeys.USER_ID to "Alice")
+
+                // When
+                val result = strategy.evaluate("test", store, context)
+
+                // Then
+                result.shouldBeTrue()
+            }
+
+            test("returns true when user ID is missing from context") {
+                // Given
+                val strategy = DenyListStrategy(setOf("Alice", "Bob"))
+                val store = InMemoryFeatureStore()
+                val context = FlippingExecutionContext()
+
+                // When
+                val result = strategy.evaluate("test", store, context)
+
+                // Then
+                result.shouldBeTrue()
+            }
+
+            test("returns false only for users in the deny list") {
+                // Given
+                val strategy = DenyListStrategy(setOf("Alice", "Charlie"))
+                val store = InMemoryFeatureStore()
+
+                // When / Then
+                strategy.evaluate("test", store, FlippingExecutionContext(ContextKeys.USER_ID to "Alice")).shouldBeFalse()
+                strategy.evaluate("test", store, FlippingExecutionContext(ContextKeys.USER_ID to "Charlie")).shouldBeFalse()
+                strategy.evaluate("test", store, FlippingExecutionContext(ContextKeys.USER_ID to "Bob")).shouldBeTrue()
+                strategy.evaluate("test", store, FlippingExecutionContext(ContextKeys.USER_ID to "David")).shouldBeTrue()
+            }
+
+            test("handles null feature store") {
+                // Given
+                val strategy = DenyListStrategy(setOf("Alice"))
+                val context = FlippingExecutionContext(ContextKeys.USER_ID to "Bob")
+
+                // When
+                val result = strategy.evaluate("test", null, context)
+
+                // Then
+                result.shouldBeTrue()
+            }
+        }
+
+        context("serialization") {
+            test("round-trip serialization preserves strategy") {
+                // Given
+                val strategy = DenyListStrategy(setOf("Alice", "Bob", "Charlie"))
+
+                // When
+                val json = FF4kJson.encodeToString<FlippingStrategy>(strategy)
+                val deserialized = FF4kJson.decodeFromString<FlippingStrategy>(json)
+
+                // Then
+                deserialized shouldBe strategy
+            }
+
+            test("round-trip serialization preserves empty list") {
+                // Given
+                val strategy = DenyListStrategy(emptySet())
+
+                // When
+                val json = FF4kJson.encodeToString<FlippingStrategy>(strategy)
+                val deserialized = FF4kJson.decodeFromString<FlippingStrategy>(json)
+
+                // Then
+                deserialized shouldBe strategy
+            }
+        }
+    }) {
+
+    override fun createStrategy(): FlippingStrategy = DenyListStrategy(setOf("Alice"))
+
+    override fun contextThatShouldPass(): FlippingExecutionContext = FlippingExecutionContext(ContextKeys.USER_ID to "Bob")
+
+    override fun contextThatShouldFail(): FlippingExecutionContext = FlippingExecutionContext(ContextKeys.USER_ID to "Alice")
+
+    override fun expectedJsonForSampleParams(): String = // language=json
+        """{"type": "denyList","denyList": ["Alice"]}"""
+}


### PR DESCRIPTION
## Summary

Add AllowListStrategy and DenyListStrategy for user-specific feature targeting with DSL support.   

## Motivation

Enable targeting specific users for feature flags - either to grant access to a select group (allow list) or to exclude specific users from a feature (deny list).                 
                                                                                                                                                                                     
Closes #21

## Changes

<!-- What does this PR do? List the main changes -->
                                                                                                                                                                                     
  - Add AllowListStrategy that enables features only for users in the specified list                                                                                                 
  - Add DenyListStrategy that disables features for users in the list, enabling for everyone else                                                                                    
  - Add DSL functions allowListStrategy and denyListStrategy with ListBuilder for fluent configuration 

## Testing

<!-- How did you test these changes? -->

- [x] Unit tests added/updated
- [x] Tested on JVM
- [x] Tested on Android
- [x] Tested on iOS

## Checklist

- [x] My code follows the project's code style (`./gradlew spotlessCheck` passes)
- [x] I have added tests that prove my fix/feature works
- [x] All tests pass (`./gradlew check`)
- [x] I have updated documentation if needed
- [ ] I marked all checkboxes without reading


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added AllowListStrategy and DenyListStrategy for granular, user-based feature control—enable or disable features for specific users while others inherit the opposite behavior.
  * New DSL support for convenient configuration of allow and deny list strategies.

* **Documentation**
  * Added comprehensive guides for the new list-based strategies with practical examples.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->