### PR TITLE
feat(strategy): add time-based flipping strategies

### DIFF
--- a/docs/strategies.md
+++ b/docs/strategies.md
@@ -94,6 +94,69 @@ feature("new-ui") {
 }
 ```
 
+### Time-Based Strategies
+
+#### ReleaseDateStrategy
+
+Enables a feature after a specified release date. The feature is disabled before the release
+date and enabled once the current time reaches or passes it.
+
+Useful for scheduling feature launches without requiring a deployment.
+
+```kotlin
+// Using ISO-8601 string
+feature("new-feature") {
+    releaseDateStrategy("2025-06-01T00:00:00Z")
+}
+
+// Using Instant
+feature("new-feature") {
+    releaseDateStrategy(Instant.parse("2025-06-01T00:00:00Z"))
+}
+
+// Using LocalDateTime with timezone
+feature("new-feature") {
+    releaseDateStrategy(
+        dateTime = LocalDateTime(2025, 6, 1, 9, 0),
+        timezone = TimeZone.of("America/New_York")
+    )
+}
+```
+
+#### DateRangeStrategy
+
+Enables a feature only within a specified time range. The feature is enabled when the current
+time is at or after the start date and before the end date (i.e., `[startDate, endDate)`).
+
+Useful for limited-time promotions, scheduled maintenance windows, or time-boxed experiments.
+
+```kotlin
+// Using ISO-8601 strings
+feature("holiday-sale") {
+    dateRangeStrategy(
+        startDate = "2025-12-20T00:00:00Z",
+        endDate = "2025-12-26T00:00:00Z"
+    )
+}
+
+// Using Instant values
+feature("maintenance-mode") {
+    dateRangeStrategy(
+        startDate = maintenanceStart,
+        endDate = maintenanceEnd
+    )
+}
+
+// Using LocalDateTime with timezone
+feature("summer-promo") {
+    dateRangeStrategy(
+        startDate = LocalDateTime(2025, 6, 1, 0, 0),
+        endDate = LocalDateTime(2025, 8, 31, 23, 59),
+        timezone = TimeZone.of("Europe/London")
+    )
+}
+```
+
 ### Composite Strategies
 
 Combine multiple strategies using logical operators.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -61,6 +61,48 @@ class MyPropertyTest : PropertyContractTest<String, MyStringProperty>() {
 }
 ```
 
+## Testing Flipping Strategies
+
+To test custom `FlippingStrategy` implementations, extend `FlippingStrategyContractTest` and implement the required methods.
+
+```kotlin
+class MyCustomStrategyTest : FlippingStrategyContractTest() {
+
+    // Create a strategy instance configured to pass with contextThatShouldPass()
+    override fun createStrategyForPassingCase(): FlippingStrategy {
+        return MyCustomStrategy(configuredToPass = true)
+    }
+
+    // Create a strategy instance configured to fail with contextThatShouldFail()
+    override fun createStrategyForFailingCase(): FlippingStrategy {
+        return MyCustomStrategy(configuredToPass = false)
+    }
+
+    // Context that should result in true when used with createStrategyForPassingCase()
+    override fun contextThatShouldPass(): FlippingExecutionContext {
+        return FlippingExecutionContext(ContextKeys.USER_ID to "allowed-user")
+    }
+
+    // Context that should result in false when used with createStrategyForFailingCase()
+    override fun contextThatShouldFail(): FlippingExecutionContext {
+        return FlippingExecutionContext(ContextKeys.USER_ID to "denied-user")
+    }
+
+    // Expected JSON serialization for the strategy from createStrategyForPassingCase()
+    override fun expectedJsonForSampleParams(): String {
+        return """{"type":"myCustom","configuredToPass":true}"""
+    }
+}
+```
+
+The contract test provides separate strategy creation methods (`createStrategyForPassingCase` and `createStrategyForFailingCase`) to support strategies that depend on injected dependencies like clocks or random sources. For context-driven strategies where the same instance can both pass and fail based on context, both methods can return the same strategy instance.
+
+The `FlippingStrategyContractTest` will automatically run tests covering:
+- Evaluation returns true for passing case
+- Evaluation returns false for failing case
+- Handling of null feature store
+- JSON serialization
+
 ## Running Tests
 
 Run your tests as you normally would use Gradle:

--- a/ff4k-contract-test/src/commonMain/kotlin/com/yonatankarp/ff4k/test/contract/strategy/FlippingStrategyContractTest.kt
+++ b/ff4k-contract-test/src/commonMain/kotlin/com/yonatankarp/ff4k/test/contract/strategy/FlippingStrategyContractTest.kt
@@ -9,6 +9,7 @@ import com.yonatankarp.ff4k.serialization.FF4kJson
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import kotlinx.serialization.PolymorphicSerializer
+import kotlinx.serialization.encodeToString
 
 /**
  * Contract test for FlippingStrategy implementations.
@@ -20,9 +21,18 @@ import kotlinx.serialization.PolymorphicSerializer
 abstract class FlippingStrategyContractTest(body: FunSpec.() -> Unit = {}) : FunSpec(body) {
 
     /**
-     * Creates an instance of the strategy being tested.
+     * Creates an instance of the strategy configured to pass when evaluated with [contextThatShouldPass].
+     * This allows strategies that depend on injected dependencies (e.g., clocks) to configure
+     * themselves appropriately for the passing test case.
      */
-    protected abstract fun createStrategy(): FlippingStrategy
+    protected abstract fun createStrategyForPassingCase(): FlippingStrategy
+
+    /**
+     * Creates an instance of the strategy configured to fail when evaluated with [contextThatShouldFail].
+     * This allows strategies that depend on injected dependencies (e.g., clocks) to configure
+     * themselves appropriately for the failing test case.
+     */
+    protected abstract fun createStrategyForFailingCase(): FlippingStrategy
 
     /**
      * Provides an execution context that should result in the strategy evaluating to true.
@@ -35,7 +45,7 @@ abstract class FlippingStrategyContractTest(body: FunSpec.() -> Unit = {}) : Fun
     protected abstract fun contextThatShouldFail(): FlippingExecutionContext
 
     /**
-     * Provides the expected JSON representation for the strategy.
+     * Provides the expected JSON representation for the strategy created by [createStrategyForPassingCase].
      * The JSON should include the polymorphic type discriminator if applicable.
      */
     protected abstract fun expectedJsonForSampleParams(): String
@@ -43,7 +53,7 @@ abstract class FlippingStrategyContractTest(body: FunSpec.() -> Unit = {}) : Fun
     init {
         test("should evaluate to true when context matches strategy criteria") {
             // Given
-            val strategy = createStrategy()
+            val strategy = createStrategyForPassingCase()
             val context = contextThatShouldPass()
 
             // When
@@ -55,7 +65,7 @@ abstract class FlippingStrategyContractTest(body: FunSpec.() -> Unit = {}) : Fun
 
         test("should evaluate to false when context does not match strategy criteria") {
             // Given
-            val strategy = createStrategy()
+            val strategy = createStrategyForFailingCase()
             val context = contextThatShouldFail()
 
             // When
@@ -67,7 +77,7 @@ abstract class FlippingStrategyContractTest(body: FunSpec.() -> Unit = {}) : Fun
 
         test("should handle null feature store") {
             // Given
-            val strategy = createStrategy()
+            val strategy = createStrategyForPassingCase()
             val context = contextThatShouldPass()
             val store: FeatureStore? = null
 
@@ -80,7 +90,7 @@ abstract class FlippingStrategyContractTest(body: FunSpec.() -> Unit = {}) : Fun
 
         test("should serialize to correct json") {
             // Given
-            val strategy = createStrategy()
+            val strategy = createStrategyForPassingCase()
             val expectedJson = FF4kJson.parseToJsonElement(expectedJsonForSampleParams())
 
             // When
@@ -89,6 +99,18 @@ abstract class FlippingStrategyContractTest(body: FunSpec.() -> Unit = {}) : Fun
 
             // Then
             actualJson shouldBe expectedJson
+        }
+
+        test("should work with round-trip serialization") {
+            // Given
+            val strategy = createStrategyForPassingCase()
+
+            // When
+            val json = FF4kJson.encodeToString<FlippingStrategy>(strategy)
+            val deserializedStrategy = FF4kJson.decodeFromString<FlippingStrategy>(json)
+
+            // Then
+            deserializedStrategy shouldBe strategy
         }
     }
 

--- a/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/dsl/strategy/StrategyDsl.kt
+++ b/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/dsl/strategy/StrategyDsl.kt
@@ -3,9 +3,15 @@ package com.yonatankarp.ff4k.dsl.strategy
 import com.yonatankarp.ff4k.dsl.core.FF4kDsl
 import com.yonatankarp.ff4k.dsl.feature.FeatureBuilder
 import com.yonatankarp.ff4k.strategy.AllowListStrategy
+import com.yonatankarp.ff4k.strategy.DateRangeStrategy
 import com.yonatankarp.ff4k.strategy.DenyListStrategy
 import com.yonatankarp.ff4k.strategy.PonderationStrategy
+import com.yonatankarp.ff4k.strategy.ReleaseDateStrategy
 import com.yonatankarp.ff4k.strategy.UserPonderationStrategy
+import kotlinx.datetime.Instant
+import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toInstant
 
 /**
  * Configures a [PonderationStrategy] for this feature with a decimal weight.
@@ -147,6 +153,165 @@ fun FeatureBuilder.allowListStrategy(block: ListBuilder.() -> Unit) {
 fun FeatureBuilder.denyListStrategy(block: ListBuilder.() -> Unit) {
     val list = ListBuilder().apply(block).build()
     flippingStrategy = DenyListStrategy(list)
+}
+
+/**
+ * Configures a [ReleaseDateStrategy] for this feature using an [Instant].
+ *
+ * The feature will be disabled before the release date and enabled once
+ * the current time reaches or passes the release date.
+ *
+ * ## Example
+ *
+ * ```kotlin
+ * feature("new-feature") {
+ *     releaseDateStrategy(Instant.parse("2025-01-01T00:00:00Z"))
+ * }
+ * ```
+ *
+ * @param releaseDate The instant after which the feature becomes enabled.
+ * @see dateRangeStrategy for enabling a feature within a time window
+ */
+fun FeatureBuilder.releaseDateStrategy(releaseDate: Instant) {
+    flippingStrategy = ReleaseDateStrategy(releaseDate)
+}
+
+/**
+ * Configures a [ReleaseDateStrategy] for this feature using an ISO-8601 date string.
+ *
+ * The feature will be disabled before the release date and enabled once
+ * the current time reaches or passes the release date.
+ *
+ * ## Example
+ *
+ * ```kotlin
+ * feature("new-feature") {
+ *     releaseDateStrategy("2025-01-01T00:00:00Z")
+ * }
+ * ```
+ *
+ * @param date The release date in ISO-8601 format (e.g., "2025-01-01T00:00:00Z").
+ * @throws IllegalArgumentException if the date string is not valid ISO-8601 format.
+ * @see dateRangeStrategy for enabling a feature within a time window
+ */
+fun FeatureBuilder.releaseDateStrategy(date: String) {
+    flippingStrategy = ReleaseDateStrategy(Instant.parse(date))
+}
+
+/**
+ * Configures a [ReleaseDateStrategy] for this feature using a [LocalDateTime] and timezone.
+ *
+ * The feature will be disabled before the release date and enabled once
+ * the current time reaches or passes the release date.
+ *
+ * ## Example
+ *
+ * ```kotlin
+ * feature("new-feature") {
+ *     releaseDateStrategy(
+ *         dateTime = LocalDateTime(2025, 1, 1, 0, 0),
+ *         timezone = TimeZone.of("America/New_York")
+ *     )
+ * }
+ * ```
+ *
+ * @param dateTime The local date and time of the release.
+ * @param timezone The timezone to interpret the local date time. Defaults to UTC.
+ * @see dateRangeStrategy for enabling a feature within a time window
+ */
+fun FeatureBuilder.releaseDateStrategy(
+    dateTime: LocalDateTime,
+    timezone: TimeZone = TimeZone.UTC,
+) {
+    flippingStrategy = ReleaseDateStrategy(dateTime.toInstant(timezone))
+}
+
+/**
+ * Configures a [DateRangeStrategy] for this feature using [Instant] values.
+ *
+ * The feature will be enabled only when the current time is within the
+ * specified range: `[startDate, endDate)` (start inclusive, end exclusive).
+ *
+ * ## Example
+ *
+ * ```kotlin
+ * feature("holiday-sale") {
+ *     dateRangeStrategy(
+ *         startDate = Instant.parse("2025-12-20T00:00:00Z"),
+ *         endDate = Instant.parse("2025-12-26T00:00:00Z")
+ *     )
+ * }
+ * ```
+ *
+ * @param startDate The instant from which the feature becomes enabled (inclusive).
+ * @param endDate The instant at which the feature becomes disabled (exclusive).
+ * @see releaseDateStrategy for enabling a feature after a single date
+ */
+fun FeatureBuilder.dateRangeStrategy(startDate: Instant, endDate: Instant) {
+    flippingStrategy = DateRangeStrategy(startDate, endDate)
+}
+
+/**
+ * Configures a [DateRangeStrategy] for this feature using ISO-8601 date strings.
+ *
+ * The feature will be enabled only when the current time is within the
+ * specified range: `[startDate, endDate)` (start inclusive, end exclusive).
+ *
+ * ## Example
+ *
+ * ```kotlin
+ * feature("holiday-sale") {
+ *     dateRangeStrategy(
+ *         startDate = "2025-12-20T00:00:00Z",
+ *         endDate = "2025-12-26T00:00:00Z"
+ *     )
+ * }
+ * ```
+ *
+ * @param startDate The start date in ISO-8601 format (e.g., "2025-01-01T00:00:00Z").
+ * @param endDate The end date in ISO-8601 format (e.g., "2025-01-31T23:59:59Z").
+ * @throws IllegalArgumentException if either date string is not valid ISO-8601 format.
+ * @see releaseDateStrategy for enabling a feature after a single date
+ */
+fun FeatureBuilder.dateRangeStrategy(startDate: String, endDate: String) {
+    flippingStrategy = DateRangeStrategy(
+        startDate = Instant.parse(startDate),
+        endDate = Instant.parse(endDate),
+    )
+}
+
+/**
+ * Configures a [DateRangeStrategy] for this feature using [LocalDateTime] values and timezone.
+ *
+ * The feature will be enabled only when the current time is within the
+ * specified range: `[startDate, endDate)` (start inclusive, end exclusive).
+ *
+ * ## Example
+ *
+ * ```kotlin
+ * feature("holiday-sale") {
+ *     dateRangeStrategy(
+ *         startDate = LocalDateTime(2025, 12, 20, 0, 0),
+ *         endDate = LocalDateTime(2025, 12, 26, 0, 0),
+ *         timezone = TimeZone.of("America/New_York")
+ *     )
+ * }
+ * ```
+ *
+ * @param startDate The local date and time when the feature becomes enabled.
+ * @param endDate The local date and time when the feature becomes disabled.
+ * @param timezone The timezone to interpret the local date times. Defaults to UTC.
+ * @see releaseDateStrategy for enabling a feature after a single date
+ */
+fun FeatureBuilder.dateRangeStrategy(
+    startDate: LocalDateTime,
+    endDate: LocalDateTime,
+    timezone: TimeZone = TimeZone.UTC,
+) {
+    flippingStrategy = DateRangeStrategy(
+        startDate = startDate.toInstant(timezone),
+        endDate = endDate.toInstant(timezone),
+    )
 }
 
 /**

--- a/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/serialization/FF4kSerializersModule.kt
+++ b/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/serialization/FF4kSerializersModule.kt
@@ -21,10 +21,12 @@ import com.yonatankarp.ff4k.strategy.AllowListStrategy
 import com.yonatankarp.ff4k.strategy.AlwaysFalseFlippingStrategy
 import com.yonatankarp.ff4k.strategy.AlwaysTrueFlippingStrategy
 import com.yonatankarp.ff4k.strategy.AndStrategy
+import com.yonatankarp.ff4k.strategy.DateRangeStrategy
 import com.yonatankarp.ff4k.strategy.DenyListStrategy
 import com.yonatankarp.ff4k.strategy.NotStrategy
 import com.yonatankarp.ff4k.strategy.OrStrategy
 import com.yonatankarp.ff4k.strategy.PonderationStrategy
+import com.yonatankarp.ff4k.strategy.ReleaseDateStrategy
 import com.yonatankarp.ff4k.strategy.UserPonderationStrategy
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.modules.SerializersModule
@@ -59,6 +61,8 @@ val ff4kSerializersModule = SerializersModule {
         subclass(UserPonderationStrategy::class, UserPonderationStrategy.serializer())
         subclass(AllowListStrategy::class, AllowListStrategy.serializer())
         subclass(DenyListStrategy::class, DenyListStrategy.serializer())
+        subclass(ReleaseDateStrategy::class, ReleaseDateStrategy.serializer())
+        subclass(DateRangeStrategy::class, DateRangeStrategy.serializer())
     }
 } + humanReadableSerializerModule
 

--- a/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/strategy/DateRangeStrategy.kt
+++ b/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/strategy/DateRangeStrategy.kt
@@ -1,0 +1,69 @@
+package com.yonatankarp.ff4k.strategy
+
+import com.yonatankarp.ff4k.core.FeatureStore
+import com.yonatankarp.ff4k.core.FlippingExecutionContext
+import com.yonatankarp.ff4k.core.FlippingStrategy
+import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.Transient
+
+/**
+ * A strategy that enables a feature only within a specified time range.
+ *
+ * The feature is enabled when the current time is at or after [startDate]
+ * and before [endDate] (i.e., the range is `[startDate, endDate)`).
+ *
+ * This strategy is useful for:
+ * - Limited-time promotions or events
+ * - Scheduled maintenance windows
+ * - Time-boxed experiments
+ *
+ * @property startDate The instant from which the feature becomes enabled (inclusive).
+ * @property endDate The instant at which the feature becomes disabled (exclusive).
+ * @property clock The clock used to determine the current time. Defaults to [Clock.System].
+ *   This parameter is marked as [Transient] and is not included in serialization.
+ *   It should only be injected for testing purposes; in production, the default
+ *   [Clock.System] will always be used (including when deserializing from JSON).
+ * @see ReleaseDateStrategy for enabling a feature after a single date
+ */
+@Serializable
+@SerialName("dateRange")
+data class DateRangeStrategy(
+    val startDate: Instant,
+    val endDate: Instant,
+    @Transient private val clock: Clock = Clock.System,
+) : FlippingStrategy {
+
+    init {
+        require(startDate <= endDate) { "endDate ($endDate) must be after startDate ($startDate) in DateRangeStrategy" }
+    }
+
+    override suspend fun evaluate(
+        featureId: String,
+        store: FeatureStore?,
+        context: FlippingExecutionContext,
+    ): Boolean {
+        val now = clock.now()
+        return now in startDate..<endDate
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+
+        other as DateRangeStrategy
+
+        if (startDate != other.startDate) return false
+        if (endDate != other.endDate) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = startDate.hashCode()
+        result = 31 * result + endDate.hashCode()
+        return result
+    }
+}

--- a/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/strategy/ReleaseDateStrategy.kt
+++ b/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/strategy/ReleaseDateStrategy.kt
@@ -1,0 +1,53 @@
+package com.yonatankarp.ff4k.strategy
+
+import com.yonatankarp.ff4k.core.FeatureStore
+import com.yonatankarp.ff4k.core.FlippingExecutionContext
+import com.yonatankarp.ff4k.core.FlippingStrategy
+import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.Transient
+
+/**
+ * A strategy that enables a feature after a specified release date.
+ *
+ * The feature is disabled before the release date and enabled once the
+ * current time reaches or passes the release date.
+ *
+ * This strategy is useful for scheduling feature launches at a specific
+ * point in time without requiring a deployment or manual toggle.
+ *
+ * @property releaseDate The instant after which the feature becomes enabled.
+ * @property clock The clock used to determine the current time. Defaults to [Clock.System].
+ *   This parameter is marked as [Transient] and is not included in serialization.
+ *   It should only be injected for testing purposes; in production, the default
+ *   [Clock.System] will always be used (including when deserializing from JSON).
+ * @see DateRangeStrategy for enabling a feature within a specific time window
+ */
+@Serializable
+@SerialName("releaseDate")
+data class ReleaseDateStrategy(
+    val releaseDate: Instant,
+    @Transient private val clock: Clock = Clock.System,
+) : FlippingStrategy {
+    override suspend fun evaluate(
+        featureId: String,
+        store: FeatureStore?,
+        context: FlippingExecutionContext,
+    ): Boolean {
+        val now = clock.now()
+        return now >= releaseDate
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+
+        other as ReleaseDateStrategy
+
+        return releaseDate == other.releaseDate
+    }
+
+    override fun hashCode(): Int = releaseDate.hashCode()
+}

--- a/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/dsl/strategy/StrategyDslTest.kt
+++ b/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/dsl/strategy/StrategyDslTest.kt
@@ -2,13 +2,19 @@ package com.yonatankarp.ff4k.dsl.strategy
 
 import com.yonatankarp.ff4k.dsl.feature.feature
 import com.yonatankarp.ff4k.strategy.AllowListStrategy
+import com.yonatankarp.ff4k.strategy.DateRangeStrategy
 import com.yonatankarp.ff4k.strategy.DenyListStrategy
 import com.yonatankarp.ff4k.strategy.PonderationStrategy
+import com.yonatankarp.ff4k.strategy.ReleaseDateStrategy
 import com.yonatankarp.ff4k.strategy.UserPonderationStrategy
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
+import kotlinx.datetime.Instant
+import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toInstant
 
 internal class StrategyDslTest :
     FunSpec({
@@ -19,7 +25,7 @@ internal class StrategyDslTest :
             }
 
             feature.flippingStrategy.shouldBeInstanceOf<PonderationStrategy>()
-            (feature.flippingStrategy as PonderationStrategy).weight shouldBe 0.75
+            feature.flippingStrategy.weight shouldBe 0.75
         }
 
         test("ponderationStrategy with Int sets strategy") {
@@ -28,7 +34,7 @@ internal class StrategyDslTest :
             }
 
             feature.flippingStrategy.shouldBeInstanceOf<PonderationStrategy>()
-            (feature.flippingStrategy as PonderationStrategy).weight shouldBe 0.5
+            feature.flippingStrategy.weight shouldBe 0.5
         }
 
         test("userPonderationStrategy with Double sets strategy") {
@@ -37,7 +43,7 @@ internal class StrategyDslTest :
             }
 
             feature.flippingStrategy.shouldBeInstanceOf<UserPonderationStrategy>()
-            (feature.flippingStrategy as UserPonderationStrategy).weight shouldBe 0.75
+            feature.flippingStrategy.weight shouldBe 0.75
         }
 
         test("userPonderationStrategy with Int sets strategy") {
@@ -46,7 +52,7 @@ internal class StrategyDslTest :
             }
 
             feature.flippingStrategy.shouldBeInstanceOf<UserPonderationStrategy>()
-            (feature.flippingStrategy as UserPonderationStrategy).weight shouldBe 0.5
+            feature.flippingStrategy.weight shouldBe 0.5
         }
 
         context("allowListStrategy") {
@@ -59,8 +65,7 @@ internal class StrategyDslTest :
                 }
 
                 feature.flippingStrategy.shouldBeInstanceOf<AllowListStrategy>()
-                (feature.flippingStrategy as AllowListStrategy).allowedList shouldContainExactlyInAnyOrder
-                    listOf("user-1", "user-2")
+                feature.flippingStrategy.allowedList shouldContainExactlyInAnyOrder listOf("user-1", "user-2")
             }
 
             test("sets AllowListStrategy with add function") {
@@ -72,8 +77,7 @@ internal class StrategyDslTest :
                 }
 
                 feature.flippingStrategy.shouldBeInstanceOf<AllowListStrategy>()
-                (feature.flippingStrategy as AllowListStrategy).allowedList shouldContainExactlyInAnyOrder
-                    listOf("user-1", "user-2")
+                feature.flippingStrategy.allowedList shouldContainExactlyInAnyOrder listOf("user-1", "user-2")
             }
 
             test("sets AllowListStrategy with addAll function") {
@@ -84,8 +88,7 @@ internal class StrategyDslTest :
                 }
 
                 feature.flippingStrategy.shouldBeInstanceOf<AllowListStrategy>()
-                (feature.flippingStrategy as AllowListStrategy).allowedList shouldContainExactlyInAnyOrder
-                    listOf("user-1", "user-2", "user-3")
+                feature.flippingStrategy.allowedList shouldContainExactlyInAnyOrder listOf("user-1", "user-2", "user-3")
             }
 
             test("sets AllowListStrategy with mixed methods") {
@@ -98,8 +101,7 @@ internal class StrategyDslTest :
                 }
 
                 feature.flippingStrategy.shouldBeInstanceOf<AllowListStrategy>()
-                (feature.flippingStrategy as AllowListStrategy).allowedList shouldContainExactlyInAnyOrder
-                    listOf("user-1", "user-2", "user-3", "user-4")
+                feature.flippingStrategy.allowedList shouldContainExactlyInAnyOrder listOf("user-1", "user-2", "user-3", "user-4")
             }
 
             test("deduplicates entries") {
@@ -112,7 +114,7 @@ internal class StrategyDslTest :
                 }
 
                 feature.flippingStrategy.shouldBeInstanceOf<AllowListStrategy>()
-                (feature.flippingStrategy as AllowListStrategy).allowedList shouldBe setOf("user-1")
+                feature.flippingStrategy.allowedList shouldBe setOf("user-1")
             }
         }
 
@@ -126,8 +128,7 @@ internal class StrategyDslTest :
                 }
 
                 feature.flippingStrategy.shouldBeInstanceOf<DenyListStrategy>()
-                (feature.flippingStrategy as DenyListStrategy).denyList shouldContainExactlyInAnyOrder
-                    listOf("user-1", "user-2")
+                feature.flippingStrategy.denyList shouldContainExactlyInAnyOrder listOf("user-1", "user-2")
             }
 
             test("sets DenyListStrategy with add function") {
@@ -139,8 +140,7 @@ internal class StrategyDslTest :
                 }
 
                 feature.flippingStrategy.shouldBeInstanceOf<DenyListStrategy>()
-                (feature.flippingStrategy as DenyListStrategy).denyList shouldContainExactlyInAnyOrder
-                    listOf("user-1", "user-2")
+                feature.flippingStrategy.denyList shouldContainExactlyInAnyOrder listOf("user-1", "user-2")
             }
 
             test("sets DenyListStrategy with addAll function") {
@@ -151,8 +151,7 @@ internal class StrategyDslTest :
                 }
 
                 feature.flippingStrategy.shouldBeInstanceOf<DenyListStrategy>()
-                (feature.flippingStrategy as DenyListStrategy).denyList shouldContainExactlyInAnyOrder
-                    listOf("user-1", "user-2", "user-3")
+                feature.flippingStrategy.denyList shouldContainExactlyInAnyOrder listOf("user-1", "user-2", "user-3")
             }
 
             test("sets DenyListStrategy with mixed methods") {
@@ -165,8 +164,7 @@ internal class StrategyDslTest :
                 }
 
                 feature.flippingStrategy.shouldBeInstanceOf<DenyListStrategy>()
-                (feature.flippingStrategy as DenyListStrategy).denyList shouldContainExactlyInAnyOrder
-                    listOf("user-1", "user-2", "user-3", "user-4")
+                feature.flippingStrategy.denyList shouldContainExactlyInAnyOrder listOf("user-1", "user-2", "user-3", "user-4")
             }
 
             test("deduplicates entries") {
@@ -179,7 +177,82 @@ internal class StrategyDslTest :
                 }
 
                 feature.flippingStrategy.shouldBeInstanceOf<DenyListStrategy>()
-                (feature.flippingStrategy as DenyListStrategy).denyList shouldBe setOf("user-1")
+                feature.flippingStrategy.denyList shouldBe setOf("user-1")
+            }
+        }
+
+        context("releaseDateStrategy") {
+            test("sets ReleaseDateStrategy with Instant") {
+                val date = Instant.parse("2025-01-01T00:00:00Z")
+                val feature = feature("test") {
+                    releaseDateStrategy(date)
+                }
+
+                feature.flippingStrategy.shouldBeInstanceOf<ReleaseDateStrategy>()
+                feature.flippingStrategy.releaseDate shouldBe date
+            }
+
+            test("sets ReleaseDateStrategy with ISO string") {
+                val dateString = "2025-01-01T00:00:00Z"
+                val feature = feature("test") {
+                    releaseDateStrategy(dateString)
+                }
+
+                feature.flippingStrategy.shouldBeInstanceOf<ReleaseDateStrategy>()
+                feature.flippingStrategy.releaseDate shouldBe Instant.parse(dateString)
+            }
+
+            test("sets ReleaseDateStrategy with LocalDateTime") {
+                val dateTime = LocalDateTime(2025, 1, 1, 0, 0)
+                val timezone = TimeZone.UTC
+                val feature = feature("test") {
+                    releaseDateStrategy(dateTime, timezone)
+                }
+
+                feature.flippingStrategy.shouldBeInstanceOf<ReleaseDateStrategy>()
+                feature.flippingStrategy.releaseDate shouldBe dateTime.toInstant(timezone)
+            }
+        }
+
+        context("dateRangeStrategy") {
+            test("sets DateRangeStrategy with Instant") {
+                val start = Instant.parse("2025-01-01T00:00:00Z")
+                val end = Instant.parse("2025-01-02T00:00:00Z")
+                val feature = feature("test") {
+                    dateRangeStrategy(start, end)
+                }
+
+                feature.flippingStrategy.shouldBeInstanceOf<DateRangeStrategy>()
+                val strategy = feature.flippingStrategy
+                strategy.startDate shouldBe start
+                strategy.endDate shouldBe end
+            }
+
+            test("sets DateRangeStrategy with ISO string") {
+                val start = "2025-01-01T00:00:00Z"
+                val end = "2025-01-02T00:00:00Z"
+                val feature = feature("test") {
+                    dateRangeStrategy(start, end)
+                }
+
+                feature.flippingStrategy.shouldBeInstanceOf<DateRangeStrategy>()
+                val strategy = feature.flippingStrategy
+                strategy.startDate shouldBe Instant.parse(start)
+                strategy.endDate shouldBe Instant.parse(end)
+            }
+
+            test("sets DateRangeStrategy with LocalDateTime") {
+                val start = LocalDateTime(2025, 1, 1, 0, 0)
+                val end = LocalDateTime(2025, 1, 2, 0, 0)
+                val timezone = TimeZone.UTC
+                val feature = feature("test") {
+                    dateRangeStrategy(start, end, timezone)
+                }
+
+                feature.flippingStrategy.shouldBeInstanceOf<DateRangeStrategy>()
+                val strategy = feature.flippingStrategy
+                strategy.startDate shouldBe start.toInstant(timezone)
+                strategy.endDate shouldBe end.toInstant(timezone)
             }
         }
     })

--- a/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/strategy/AllowListStrategyTest.kt
+++ b/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/strategy/AllowListStrategyTest.kt
@@ -93,12 +93,14 @@ internal class AllowListStrategyTest :
         }
     }) {
 
-    override fun createStrategy(): FlippingStrategy = AllowListStrategy(setOf("Alice"))
+    override fun createStrategyForPassingCase(): FlippingStrategy = AllowListStrategy(setOf("Alice"))
+
+    override fun createStrategyForFailingCase(): FlippingStrategy = AllowListStrategy(setOf("Alice"))
 
     override fun contextThatShouldPass(): FlippingExecutionContext = FlippingExecutionContext(ContextKeys.USER_ID to "Alice")
 
     override fun contextThatShouldFail(): FlippingExecutionContext = FlippingExecutionContext(ContextKeys.USER_ID to "Bob")
 
     override fun expectedJsonForSampleParams(): String = // language=json
-        """{"type": "allowList","allowedList": ["Alice"]}"""
+        """{"type":"allowList","allowedList":["Alice"]}"""
 }

--- a/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/strategy/DateRangeStrategyTest.kt
+++ b/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/strategy/DateRangeStrategyTest.kt
@@ -1,0 +1,155 @@
+package com.yonatankarp.ff4k.strategy
+
+import com.yonatankarp.ff4k.core.FlippingExecutionContext
+import com.yonatankarp.ff4k.core.FlippingStrategy
+import com.yonatankarp.ff4k.store.InMemoryFeatureStore
+import com.yonatankarp.ff4k.test.contract.strategy.FlippingStrategyContractTest
+import com.yonatankarp.ff4k.utils.fixedClock
+import io.kotest.matchers.booleans.shouldBeFalse
+import io.kotest.matchers.booleans.shouldBeTrue
+import kotlinx.datetime.Instant
+import kotlin.time.Duration.Companion.days
+import kotlin.time.Duration.Companion.milliseconds
+
+internal class DateRangeStrategyTest :
+    FlippingStrategyContractTest({
+
+        val startDate = Instant.parse("2025-01-01T00:00:00.000Z")
+        val endDate = Instant.parse("2025-01-30T00:00:00.000Z")
+
+        context("evaluate boundary conditions") {
+            test("throws IllegalArgumentException when startDate is after endDate") {
+                io.kotest.assertions.throwables.shouldThrow<IllegalArgumentException> {
+                    DateRangeStrategy(
+                        startDate = endDate,
+                        endDate = startDate,
+                    )
+                }
+            }
+
+            test("returns true when now equals startDate (inclusive)") {
+                // Given
+                val strategy = DateRangeStrategy(
+                    startDate = startDate,
+                    endDate = endDate,
+                    clock = fixedClock(startDate),
+                )
+                val store = InMemoryFeatureStore()
+                val context = FlippingExecutionContext()
+
+                // When
+                val result = strategy.evaluate("test", store, context)
+
+                // Then
+                result.shouldBeTrue()
+            }
+
+            test("returns false when now equals endDate (exclusive)") {
+                // Given
+                val strategy = DateRangeStrategy(
+                    startDate = startDate,
+                    endDate = endDate,
+                    clock = fixedClock(endDate),
+                )
+                val store = InMemoryFeatureStore()
+                val context = FlippingExecutionContext()
+
+                // When
+                val result = strategy.evaluate("test", store, context)
+
+                // Then
+                result.shouldBeFalse()
+            }
+
+            test("returns true when now is 1ms after startDate") {
+                // Given
+                val strategy = DateRangeStrategy(
+                    startDate = startDate,
+                    endDate = endDate,
+                    clock = fixedClock(startDate.plus(1.milliseconds)),
+                )
+                val store = InMemoryFeatureStore()
+                val context = FlippingExecutionContext()
+
+                // When
+                val result = strategy.evaluate("test", store, context)
+
+                // Then
+                result.shouldBeTrue()
+            }
+
+            test("returns true when now is 1ms before endDate") {
+                // Given
+                val strategy = DateRangeStrategy(
+                    startDate = startDate,
+                    endDate = endDate,
+                    clock = fixedClock(endDate.minus(1.milliseconds)),
+                )
+                val store = InMemoryFeatureStore()
+                val context = FlippingExecutionContext()
+
+                // When
+                val result = strategy.evaluate("test", store, context)
+
+                // Then
+                result.shouldBeTrue()
+            }
+
+            test("returns false when now is 1ms before startDate") {
+                // Given
+                val strategy = DateRangeStrategy(
+                    startDate = startDate,
+                    endDate = endDate,
+                    clock = fixedClock(startDate.minus(1.milliseconds)),
+                )
+                val store = InMemoryFeatureStore()
+                val context = FlippingExecutionContext()
+
+                // When
+                val result = strategy.evaluate("test", store, context)
+
+                // Then
+                result.shouldBeFalse()
+            }
+
+            test("returns false when now is 1ms after endDate") {
+                // Given
+                val strategy = DateRangeStrategy(
+                    startDate = startDate,
+                    endDate = endDate,
+                    clock = fixedClock(endDate.plus(1.milliseconds)),
+                )
+                val store = InMemoryFeatureStore()
+                val context = FlippingExecutionContext()
+
+                // When
+                val result = strategy.evaluate("test", store, context)
+
+                // Then
+                result.shouldBeFalse()
+            }
+        }
+    }) {
+
+    private val startDate = Instant.parse("2025-01-01T00:00:00.000Z")
+    private val endDate = Instant.parse("2025-01-30T00:00:00.000Z")
+
+    override fun createStrategyForPassingCase(): FlippingStrategy = DateRangeStrategy(
+        startDate = startDate,
+        endDate = endDate,
+        clock = fixedClock(startDate.plus(1.days)),
+    )
+
+    override fun createStrategyForFailingCase(): FlippingStrategy = DateRangeStrategy(
+        startDate = startDate,
+        endDate = endDate,
+        clock = fixedClock(startDate.minus(1.days)),
+    )
+
+    override fun contextThatShouldPass(): FlippingExecutionContext = FlippingExecutionContext()
+
+    override fun contextThatShouldFail(): FlippingExecutionContext = FlippingExecutionContext()
+
+    override fun expectedJsonForSampleParams(): String = // language=json
+        """{"type":"dateRange","startDate":"2025-01-01T00:00:00Z","endDate":"2025-01-30T00:00:00Z"}"""
+}

--- a/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/strategy/DenyListStrategyTest.kt
+++ b/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/strategy/DenyListStrategyTest.kt
@@ -93,12 +93,14 @@ internal class DenyListStrategyTest :
         }
     }) {
 
-    override fun createStrategy(): FlippingStrategy = DenyListStrategy(setOf("Alice"))
+    override fun createStrategyForPassingCase(): FlippingStrategy = DenyListStrategy(setOf("Alice"))
+
+    override fun createStrategyForFailingCase(): FlippingStrategy = DenyListStrategy(setOf("Alice"))
 
     override fun contextThatShouldPass(): FlippingExecutionContext = FlippingExecutionContext(ContextKeys.USER_ID to "Bob")
 
     override fun contextThatShouldFail(): FlippingExecutionContext = FlippingExecutionContext(ContextKeys.USER_ID to "Alice")
 
     override fun expectedJsonForSampleParams(): String = // language=json
-        """{"type": "denyList","denyList": ["Alice"]}"""
+        """{"type":"denyList","denyList":["Alice"]}"""
 }

--- a/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/strategy/ReleaseDateStrategyTest.kt
+++ b/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/strategy/ReleaseDateStrategyTest.kt
@@ -1,0 +1,121 @@
+package com.yonatankarp.ff4k.strategy
+
+import com.yonatankarp.ff4k.core.FlippingExecutionContext
+import com.yonatankarp.ff4k.core.FlippingStrategy
+import com.yonatankarp.ff4k.store.InMemoryFeatureStore
+import com.yonatankarp.ff4k.test.contract.strategy.FlippingStrategyContractTest
+import com.yonatankarp.ff4k.utils.fixedClock
+import io.kotest.matchers.booleans.shouldBeFalse
+import io.kotest.matchers.booleans.shouldBeTrue
+import kotlinx.datetime.Instant
+import kotlin.time.Duration.Companion.milliseconds
+
+internal class ReleaseDateStrategyTest :
+    FlippingStrategyContractTest({
+
+        val releaseDate = Instant.parse("2025-12-08T00:00:00.000Z")
+
+        context("evaluate boundary conditions") {
+            test("returns true when now equals releaseDate (inclusive)") {
+                // Given
+                val strategy = ReleaseDateStrategy(
+                    releaseDate = releaseDate,
+                    clock = fixedClock(releaseDate),
+                )
+                val store = InMemoryFeatureStore()
+                val context = FlippingExecutionContext()
+
+                // When
+                val result = strategy.evaluate("test", store, context)
+
+                // Then
+                result.shouldBeTrue()
+            }
+
+            test("returns true when now is 1ms after releaseDate") {
+                // Given
+                val strategy = ReleaseDateStrategy(
+                    releaseDate = releaseDate,
+                    clock = fixedClock(releaseDate.plus(1.milliseconds)),
+                )
+                val store = InMemoryFeatureStore()
+                val context = FlippingExecutionContext()
+
+                // When
+                val result = strategy.evaluate("test", store, context)
+
+                // Then
+                result.shouldBeTrue()
+            }
+
+            test("returns false when now is 1ms before releaseDate") {
+                // Given
+                val strategy = ReleaseDateStrategy(
+                    releaseDate = releaseDate,
+                    clock = fixedClock(releaseDate.minus(1.milliseconds)),
+                )
+                val store = InMemoryFeatureStore()
+                val context = FlippingExecutionContext()
+
+                // When
+                val result = strategy.evaluate("test", store, context)
+
+                // Then
+                result.shouldBeFalse()
+            }
+
+            test("returns true when now is far in the future") {
+                // Given
+                val farFuture = Instant.parse("2099-01-01T00:00:00.000Z")
+                val strategy = ReleaseDateStrategy(
+                    releaseDate = releaseDate,
+                    clock = fixedClock(farFuture),
+                )
+                val store = InMemoryFeatureStore()
+                val context = FlippingExecutionContext()
+
+                // When
+                val result = strategy.evaluate("test", store, context)
+
+                // Then
+                result.shouldBeTrue()
+            }
+
+            test("returns false when now is far in the past") {
+                // Given
+                val farPast = Instant.parse("2000-01-01T00:00:00.000Z")
+                val strategy = ReleaseDateStrategy(
+                    releaseDate = releaseDate,
+                    clock = fixedClock(farPast),
+                )
+                val store = InMemoryFeatureStore()
+                val context = FlippingExecutionContext()
+
+                // When
+                val result = strategy.evaluate("test", store, context)
+
+                // Then
+                result.shouldBeFalse()
+            }
+        }
+    }) {
+
+    private val releaseDate = Instant.parse("2025-12-08T00:00:00.000Z")
+
+    override fun createStrategyForPassingCase(): FlippingStrategy = ReleaseDateStrategy(
+        releaseDate = releaseDate,
+        clock = fixedClock(releaseDate),
+    )
+
+    override fun createStrategyForFailingCase(): FlippingStrategy = ReleaseDateStrategy(
+        releaseDate = releaseDate,
+        clock = fixedClock(Instant.parse("2025-12-07T23:59:59.999Z")),
+    )
+
+    override fun contextThatShouldPass(): FlippingExecutionContext = FlippingExecutionContext()
+
+    override fun contextThatShouldFail(): FlippingExecutionContext = FlippingExecutionContext()
+
+    override fun expectedJsonForSampleParams(): String = // language=json
+        """{"type":"releaseDate","releaseDate":"2025-12-08T00:00:00Z"}"""
+}

--- a/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/strategy/UserPonderationStrategyTest.kt
+++ b/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/strategy/UserPonderationStrategyTest.kt
@@ -127,11 +127,13 @@ internal class UserPonderationStrategyTest :
         }
     }) {
 
-    override fun createStrategy(): FlippingStrategy = UserPonderationStrategy(weight = 1.0)
+    override fun createStrategyForPassingCase(): FlippingStrategy = UserPonderationStrategy(weight = 1.0)
+
+    override fun createStrategyForFailingCase(): FlippingStrategy = UserPonderationStrategy(weight = 0.0)
 
     override fun contextThatShouldPass(): FlippingExecutionContext = FlippingExecutionContext(ContextKeys.USER_ID to "test-user")
 
-    override fun contextThatShouldFail(): FlippingExecutionContext = FlippingExecutionContext()
+    override fun contextThatShouldFail(): FlippingExecutionContext = FlippingExecutionContext(ContextKeys.USER_ID to "test-user")
 
     override fun expectedJsonForSampleParams(): String = // language=json
         """{"type":"userPonderation","weight":1.0}"""

--- a/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/utils/ClockExtensions.kt
+++ b/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/utils/ClockExtensions.kt
@@ -1,0 +1,8 @@
+package com.yonatankarp.ff4k.utils
+
+import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
+
+fun fixedClock(instant: Instant): Clock = object : Clock {
+    override fun now(): Instant = instant
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -32,6 +32,7 @@ nav:
   - Home: index.md
   - Usage: usage.md
   - Properties: properties.md
+  - Strategies: strategies.md
   - Testing: testing.md
   - Extending: extending.md
   - API Reference: https://yonatankarp.github.io/ff4k/api/


### PR DESCRIPTION
## Summary

Adds two new time-based flipping strategies (ReleaseDateStrategy and DateRangeStrategy) that enable scheduling feature flag behavior without requiring deployments, along with comprehensive DSL support and documentation. 

## Motivation

<!-- Why is this change needed? Link to related issue if applicable -->

Time-based feature control is a common requirement for scheduling feature launches, running limited-time promotions, or defining maintenance windows. These strategies allow teams to pre-configure feature availability based on time without manual intervention.

Closes #22

## Changes

<!-- What does this PR do? List the main changes -->

  - Add ReleaseDateStrategy to enable features after a specified instant                                                                                                             
  - Add DateRangeStrategy to enable features within a time window (start inclusive, end exclusive)                                                                                   
  - Add DSL extensions supporting Instant, ISO-8601 strings, and LocalDateTime with timezone                                                                                         
  - Register both strategies in the serialization module for JSON support                                                                                                            
  - Refactor FlippingStrategyContractTest to support strategies with injected dependencies (e.g., clocks) via separate createStrategyForPassingCase() and                            
  createStrategyForFailingCase() methods                                                                                                                                             
  - Add fixedClock() test utility for deterministic time-based testing                                                                                                               
  - Document clock injection behavior (transient, testing-only, defaults to Clock.System on deserialization)  

## Testing

<!-- How did you test these changes? -->

- [x] Unit tests added/updated
- [x] Tested on JVM
- [x] Tested on Android
- [x] Tested on iOS

## Checklist

- [x] My code follows the project's code style (`./gradlew spotlessCheck` passes)
- [x] I have added tests that prove my fix/feature works
- [x] All tests pass (`./gradlew check`)
- [x] I have updated documentation if needed
- [ ] I marked all checkboxes without reading


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added ReleaseDate and DateRange time-based strategies with DSL helpers and multiple date format support
  * Serialization support added for the new strategies

* **Documentation**
  * New "Strategies" docs with usage examples and updated testing guidance

* **Tests**
  * Expanded contract and unit tests for time-based strategies and improved test utilities
  * Contract tests split to explicitly cover passing and failing cases

* **Chores**
  * Navigation updated to include the new Strategies docs
<!-- end of auto-generated comment: release notes by coderabbit.ai -->