### PR TITLE
feat(build): make platform targets conditional on environment

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,10 +4,38 @@ Thank you for your interest in contributing to FF4K! This document provides guid
 
 ## Getting Started
 
-### Prerequisites
+### Building Locally
 
-- JDK 17 or later
-- Gradle 8.x (wrapper included)
+This project uses an **adaptive build system** that automatically enables or disables platform targets based on the tools available in your environment.
+
+#### 1. Default Behavior
+*   **JVM:** Always built.
+*   **Android:** Built only if the Android SDK is detected.
+*   **Apple (iOS):** Built only if running on macOS with Xcode Command Line Tools installed.
+
+#### 2. Prerequisites
+
+To build all targets, including Android and iOS, ensure you have the following:
+
+*   **Java Development Kit (JDK):**
+    *   **Version 17 or higher** is required for all builds.
+*   **Android SDK:**
+    *   Set the `ANDROID_HOME` or `ANDROID_SDK_ROOT` environment variable.
+    *   **OR** create a `local.properties` file in the project root with `sdk.dir=/path/to/android/sdk`.
+*   **Apple (macOS only):**
+    *   Xcode or Command Line Tools (`xcode-select --install`).
+
+#### 3. Customizing the Build
+
+You can manually control build options by creating a `local.properties` file in the project root:
+
+```properties
+# Path to Android SDK (automatically added by Android Studio)
+sdk.dir=/Users/username/Library/Android/sdk
+
+# Explicitly disable Apple targets (even on macOS) to speed up the build
+ff4k.include.apple=false
+```
 
 ### Building the Project
 

--- a/build-logic/src/main/kotlin/ff4k.multiplatform.gradle.kts
+++ b/build-logic/src/main/kotlin/ff4k.multiplatform.gradle.kts
@@ -1,3 +1,7 @@
+import com.android.build.gradle.LibraryExtension
+import java.io.File
+import java.util.Properties
+import org.gradle.api.JavaVersion
 import org.gradle.api.artifacts.VersionCatalogsExtension
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.targets.native.tasks.KotlinNativeTest
@@ -5,7 +9,34 @@ import org.jetbrains.kotlin.gradle.targets.native.tasks.KotlinNativeTest
 plugins {
     id("org.jetbrains.kotlin.multiplatform")
     id("com.diffplug.spotless")
-    id("com.android.library")
+}
+
+val androidSdkAvailable: Boolean by lazy {
+    val env = System.getenv("ANDROID_HOME") ?: System.getenv("ANDROID_SDK_ROOT")
+    if (env != null && File(env).exists()) return@lazy true
+    val localProperties = project.rootProject.file("local.properties")
+    if (localProperties.exists()) {
+        val properties = Properties()
+        localProperties.inputStream().use { properties.load(it) }
+        val sdkDir = properties.getProperty("sdk.dir")
+        return@lazy sdkDir != null && File(sdkDir).exists()
+    }
+    false
+}
+val appleTargetsAvailable: Boolean by lazy {
+    val localProperties = project.rootProject.file("local.properties")
+    if (localProperties.exists()) {
+        val properties = Properties()
+        localProperties.inputStream().use { properties.load(it) }
+        if (properties.getProperty("ff4k.include.apple") == "false") return@lazy false
+    }
+    val osName = System.getProperty("os.name")
+    if (!osName.contains("Mac", ignoreCase = true)) return@lazy false
+    File("/usr/bin/xcrun").exists()
+}
+
+if (androidSdkAvailable) {
+    apply(plugin = "com.android.library")
 }
 
 val libs = extensions.getByType<VersionCatalogsExtension>().named("libs")
@@ -15,18 +46,22 @@ kotlin {
         libs.findVersion("jvm-toolchain").get().requiredVersion.toInt()
     )
 
-    androidTarget {
-        publishLibraryVariants("release")
-        compilerOptions {
-            jvmTarget.set(JvmTarget.JVM_11)
+    if (androidSdkAvailable) {
+        androidTarget {
+            publishLibraryVariants("release")
+            compilerOptions {
+                jvmTarget.set(JvmTarget.JVM_11)
+            }
         }
     }
 
     jvm()
 
-    iosX64()
-    iosArm64()
-    iosSimulatorArm64()
+    if (appleTargetsAvailable) {
+        iosX64()
+        iosArm64()
+        iosSimulatorArm64()
+    }
 
     applyDefaultHierarchyTemplate()
 
@@ -43,15 +78,17 @@ kotlin {
             dependsOn(jvmSharedMain)
         }
 
-        androidMain {
-            dependsOn(jvmSharedMain)
+        if (androidSdkAvailable) {
+            val androidMain by getting {
+                dependsOn(jvmSharedMain)
+            }
+
+            named("androidUnitTest") {
+                dependsOn(jvmSharedTest)
+            }
         }
 
         jvmTest {
-            dependsOn(jvmSharedTest)
-        }
-
-        named("androidUnitTest") {
             dependsOn(jvmSharedTest)
         }
 
@@ -74,25 +111,27 @@ dependencies {
     "jvmSharedTestImplementation"(libs.findLibrary("kotest-runner-junit5").get())
 }
 
-android {
-    namespace = "com.yonatankarp.${project.name.replace("-", ".")}"
-    compileSdk = 34
-    defaultConfig {
-        minSdk = 24
-    }
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_11
-        targetCompatibility = JavaVersion.VERSION_11
-    }
-    testOptions {
-        unitTests {
-            isIncludeAndroidResources = true
-            isReturnDefaultValues = true
+if (androidSdkAvailable) {
+    extensions.configure<LibraryExtension> {
+        namespace = "com.yonatankarp.${project.name.replace("-", ".")}"
+        compileSdk = 34
+        defaultConfig {
+            minSdk = 24
         }
-    }
-    sourceSets {
-        named("test") {
-            resources.srcDir("src/commonTest/resources")
+        compileOptions {
+            sourceCompatibility = JavaVersion.VERSION_11
+            targetCompatibility = JavaVersion.VERSION_11
+        }
+        testOptions {
+            unitTests {
+                isIncludeAndroidResources = true
+                isReturnDefaultValues = true
+            }
+        }
+        sourceSets {
+            named("test") {
+                resources.srcDir("src/commonTest/resources")
+            }
         }
     }
 }

--- a/ff4k-core/build.gradle.kts
+++ b/ff4k-core/build.gradle.kts
@@ -25,6 +25,8 @@ kotlin {
     }
 }
 
-dependencies {
-    add("androidUnitTestImplementation", libs.robolectric)
+if (pluginManager.hasPlugin("com.android.library")) {
+    dependencies {
+        add("androidUnitTestImplementation", libs.robolectric)
+    }
 }


### PR DESCRIPTION
## Summary

Implemented an adaptive build system that automatically detects available tools (Android SDK, Xcode) and configures the project targets accordingly.

## Motivation

To allow the project to build successfully in environments where not all platform SDKs are installed (e.g., CI, Linux machines, or developers without Android Studio), ensuring that missing tools do not block development on supported platforms.

Closes #153

## Changes

- Modified `build-logic` to check for `ANDROID_HOME`/`sdk.dir` and `xcrun` before enabling Android or Apple targets.
- Added `ff4k.include.apple` property support in `local.properties` for manual opt-out.
- Updated `ff4k-core` to conditionally depend on Robolectric.
- Updated `CONTRIBUTING.md` with new "Building Locally" instructions.

## Testing

- [x] Unit tests added/updated
- [x] Tested on JVM
- [x] Tested on Android
- [x] Tested on iOS

## Checklist

- [x] My code follows the project's code style (`./gradlew spotlessCheck` passes)
- [x] I have added tests that prove my fix/feature works
- [x] All tests pass (`./gradlew check`)
- [x] I have updated documentation if needed
- [ ] I marked all checkboxes without reading


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contributor guide with expanded "Building Locally" section covering JVM, Android, and Apple platform requirements and setup instructions.

* **Chores**
  * Implemented adaptive build system that automatically detects available SDKs and conditionally enables platform-specific builds. Developers can now customize local builds via configuration options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->