### PR TITLE
refactor(build): split platform-specific build logic

### DIFF
--- a/build-logic/src/main/kotlin/ff4k.android.gradle.kts
+++ b/build-logic/src/main/kotlin/ff4k.android.gradle.kts
@@ -1,0 +1,68 @@
+import java.io.File
+import java.util.Properties
+import com.android.build.gradle.LibraryExtension
+import org.gradle.api.JavaVersion
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
+
+val androidSdkAvailable: Boolean by lazy {
+    val env = System.getenv("ANDROID_HOME") ?: System.getenv("ANDROID_SDK_ROOT")
+    if (env != null && File(env).exists()) return@lazy true
+    val localProperties = project.rootProject.file("local.properties")
+    if (localProperties.exists()) {
+        val properties = Properties()
+        localProperties.inputStream().use { properties.load(it) }
+        val sdkDir = properties.getProperty("sdk.dir")
+        return@lazy sdkDir != null && File(sdkDir).exists()
+    }
+    false
+}
+
+if (androidSdkAvailable) {
+    apply(plugin = "com.android.library")
+
+    configure<KotlinMultiplatformExtension> {
+        androidTarget {
+            publishLibraryVariants("release")
+            compilerOptions {
+                jvmTarget.set(JvmTarget.JVM_11)
+            }
+        }
+
+        sourceSets {
+            val jvmSharedMain = findByName("jvmSharedMain")
+            val jvmSharedTest = findByName("jvmSharedTest")
+
+            named("androidMain") {
+                jvmSharedMain?.let { dependsOn(it) }
+            }
+
+            named("androidUnitTest") {
+                jvmSharedTest?.let { dependsOn(it) }
+            }
+        }
+    }
+
+    extensions.configure<LibraryExtension> {
+        namespace = "com.yonatankarp.${project.name.replace("-", ".")}"
+        compileSdk = 34
+        defaultConfig {
+            minSdk = 24
+        }
+        compileOptions {
+            sourceCompatibility = JavaVersion.VERSION_11
+            targetCompatibility = JavaVersion.VERSION_11
+        }
+        testOptions {
+            unitTests {
+                isIncludeAndroidResources = true
+                isReturnDefaultValues = true
+            }
+        }
+        sourceSets {
+            named("test") {
+                resources.srcDir("src/commonTest/resources")
+            }
+        }
+    }
+}

--- a/build-logic/src/main/kotlin/ff4k.ios.gradle.kts
+++ b/build-logic/src/main/kotlin/ff4k.ios.gradle.kts
@@ -1,0 +1,29 @@
+import java.io.File
+import java.util.Properties
+import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
+import org.jetbrains.kotlin.gradle.targets.native.tasks.KotlinNativeTest
+
+val appleTargetsAvailable: Boolean by lazy {
+    val localProperties = project.rootProject.file("local.properties")
+    if (localProperties.exists()) {
+        val properties = Properties()
+        localProperties.inputStream().use { properties.load(it) }
+        if (properties.getProperty("ff4k.include.apple") == "false") return@lazy false
+    }
+    val osName = System.getProperty("os.name")
+    if (!osName.contains("Mac", ignoreCase = true)) return@lazy false
+    File("/usr/bin/xcrun").exists()
+}
+
+if (appleTargetsAvailable) {
+    configure<KotlinMultiplatformExtension> {
+        iosX64()
+        iosArm64()
+        iosSimulatorArm64()
+    }
+
+    val resourcesDir = project.file("src/commonTest/resources")
+    tasks.withType<KotlinNativeTest> {
+        environment("FF4K_RESOURCES_PATH", resourcesDir.absolutePath)
+    }
+}

--- a/build-logic/src/main/kotlin/ff4k.jvm.gradle.kts
+++ b/build-logic/src/main/kotlin/ff4k.jvm.gradle.kts
@@ -1,0 +1,18 @@
+import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
+
+configure<KotlinMultiplatformExtension> {
+    jvm()
+
+    sourceSets {
+        val jvmSharedMain = findByName("jvmSharedMain")
+        val jvmSharedTest = findByName("jvmSharedTest")
+
+        named("jvmMain") {
+            jvmSharedMain?.let { dependsOn(it) }
+        }
+
+        named("jvmTest") {
+            jvmSharedTest?.let { dependsOn(it) }
+        }
+    }
+}

--- a/build-logic/src/main/kotlin/ff4k.multiplatform.gradle.kts
+++ b/build-logic/src/main/kotlin/ff4k.multiplatform.gradle.kts
@@ -1,42 +1,8 @@
-import com.android.build.gradle.LibraryExtension
-import java.io.File
-import java.util.Properties
-import org.gradle.api.JavaVersion
 import org.gradle.api.artifacts.VersionCatalogsExtension
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
-import org.jetbrains.kotlin.gradle.targets.native.tasks.KotlinNativeTest
 
 plugins {
     id("org.jetbrains.kotlin.multiplatform")
     id("com.diffplug.spotless")
-}
-
-val androidSdkAvailable: Boolean by lazy {
-    val env = System.getenv("ANDROID_HOME") ?: System.getenv("ANDROID_SDK_ROOT")
-    if (env != null && File(env).exists()) return@lazy true
-    val localProperties = project.rootProject.file("local.properties")
-    if (localProperties.exists()) {
-        val properties = Properties()
-        localProperties.inputStream().use { properties.load(it) }
-        val sdkDir = properties.getProperty("sdk.dir")
-        return@lazy sdkDir != null && File(sdkDir).exists()
-    }
-    false
-}
-val appleTargetsAvailable: Boolean by lazy {
-    val localProperties = project.rootProject.file("local.properties")
-    if (localProperties.exists()) {
-        val properties = Properties()
-        localProperties.inputStream().use { properties.load(it) }
-        if (properties.getProperty("ff4k.include.apple") == "false") return@lazy false
-    }
-    val osName = System.getProperty("os.name")
-    if (!osName.contains("Mac", ignoreCase = true)) return@lazy false
-    File("/usr/bin/xcrun").exists()
-}
-
-if (androidSdkAvailable) {
-    apply(plugin = "com.android.library")
 }
 
 val libs = extensions.getByType<VersionCatalogsExtension>().named("libs")
@@ -46,62 +12,30 @@ kotlin {
         libs.findVersion("jvm-toolchain").get().requiredVersion.toInt()
     )
 
-    if (androidSdkAvailable) {
-        androidTarget {
-            publishLibraryVariants("release")
-            compilerOptions {
-                jvmTarget.set(JvmTarget.JVM_11)
-            }
-        }
-    }
-
-    jvm()
-
-    if (appleTargetsAvailable) {
-        iosX64()
-        iosArm64()
-        iosSimulatorArm64()
-    }
-
     applyDefaultHierarchyTemplate()
 
     sourceSets {
+        val commonMain by getting {
+            dependencies {
+                implementation(libs.findLibrary("kotlinx-coroutines-core").get())
+            }
+        }
+        val commonTest by getting {
+            dependencies {
+                implementation(libs.findBundle("kotest").get())
+            }
+        }
+
         val jvmSharedMain by creating {
-            dependsOn(commonMain.get())
+            dependsOn(commonMain)
         }
 
         val jvmSharedTest by creating {
-            dependsOn(commonTest.get())
-        }
-
-        jvmMain {
-            dependsOn(jvmSharedMain)
-        }
-
-        if (androidSdkAvailable) {
-            val androidMain by getting {
-                dependsOn(jvmSharedMain)
-            }
-
-            named("androidUnitTest") {
-                dependsOn(jvmSharedTest)
-            }
-        }
-
-        jvmTest {
-            dependsOn(jvmSharedTest)
-        }
-
-        commonMain.dependencies {
-            implementation(libs.findLibrary("kotlinx-coroutines-core").get())
-        }
-        commonTest.dependencies {
-            implementation(libs.findBundle("kotest").get())
+            dependsOn(commonTest)
         }
     }
 }
 
-// Add JVM stdlib visibility for jvmShared source sets (IDE support)
 dependencies {
     "jvmSharedMainCompileOnly"(kotlin("stdlib"))
     "jvmSharedMainCompileOnly"(libs.findLibrary("kotlinx-coroutines-core").get())
@@ -111,36 +45,9 @@ dependencies {
     "jvmSharedTestImplementation"(libs.findLibrary("kotest-runner-junit5").get())
 }
 
-if (androidSdkAvailable) {
-    extensions.configure<LibraryExtension> {
-        namespace = "com.yonatankarp.${project.name.replace("-", ".")}"
-        compileSdk = 34
-        defaultConfig {
-            minSdk = 24
-        }
-        compileOptions {
-            sourceCompatibility = JavaVersion.VERSION_11
-            targetCompatibility = JavaVersion.VERSION_11
-        }
-        testOptions {
-            unitTests {
-                isIncludeAndroidResources = true
-                isReturnDefaultValues = true
-            }
-        }
-        sourceSets {
-            named("test") {
-                resources.srcDir("src/commonTest/resources")
-            }
-        }
-    }
-}
-
-// Configure native test tasks to find test resources
-val resourcesDir = project.file("src/commonTest/resources")
-tasks.withType<KotlinNativeTest> {
-    environment("FF4K_RESOURCES_PATH", resourcesDir.absolutePath)
-}
+apply(plugin = "ff4k.jvm")
+apply(plugin = "ff4k.android")
+apply(plugin = "ff4k.ios")
 
 tasks.withType<Test> {
     useJUnitPlatform()


### PR DESCRIPTION
## Summary

Refactored the monolithic `ff4k.multiplatform` build logic into modular, platform-specific plugins (JVM, Android, iOS) to improve readability and maintainability.

## Motivation

The `ff4k.multiplatform` plugin was becoming polluted with platform-specific logic. Splitting this into dedicated plugins (`ff4k.jvm`, `ff4k.android`, `ff4k.ios`) makes the build logic cleaner, easier to understand, and more extensible while maintaining a unified API for the consumers.

## Changes

<!-- What does this PR do? List the main changes -->

   - Created build-logic/src/main/kotlin/ff4k.jvm.gradle.kts for JVM target configuration.
   - Created build-logic/src/main/kotlin/ff4k.android.gradle.kts for Android target and library configuration.
   - Created build-logic/src/main/kotlin/ff4k.ios.gradle.kts for iOS targets configuration.
   - Updated build-logic/src/main/kotlin/ff4k.multiplatform.gradle.kts to act as a composite plugin that applies the above platform plugins.


## Testing

<!-- How did you test these changes? -->

- [X] Unit tests added/updated
- [X] Tested on JVM
- [X] Tested on Android
- [X] Tested on iOS

## Checklist

- [X] My code follows the project's code style (`./gradlew spotlessCheck` passes)
- [ ] I have added tests that prove my fix/feature works
- [X] All tests pass (`./gradlew check`)
- [ ] I have updated documentation if needed
- [ ] I marked all checkboxes without reading


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reorganized build configuration for improved modularity across platforms (Android, iOS, JVM).
  * Simplified core multiplatform configuration by extracting platform-specific setup into dedicated build scripts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->