### PR TITLE
feat(core): add getOrThrow extension for FlippingExecutionContext

### DIFF
--- a/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/core/FlippingExecutionContexts.kt
+++ b/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/core/FlippingExecutionContexts.kt
@@ -144,3 +144,26 @@ suspend inline fun <T> withFlippingParameters(
  * @return The current [FlippingExecutionContext], or an empty context if none is set
  */
 suspend fun currentFlippingContext(): FlippingExecutionContext = currentCoroutineContext()[FlippingExecutionContext] ?: FlippingExecutionContext()
+
+/**
+ * Retrieves a required parameter from the context, throwing if not present.
+ *
+ * Use this when a parameter is mandatory for your strategy or feature flag evaluation.
+ * Provides a descriptive error message indicating which parameter is missing.
+ *
+ * Example:
+ * ```kotlin
+ * class MyStrategy : FlippingStrategy {
+ *     override fun evaluate(context: FlippingExecutionContext): Boolean {
+ *         val userId: String = context.getOrThrow(ContextKeys.USER_ID)
+ *         // userId is guaranteed to be non-null here
+ *         return userId.startsWith("premium_")
+ *     }
+ * }
+ * ```
+ *
+ * @param key The parameter key to retrieve
+ * @return The value associated with the key, cast to type [T]
+ * @throws IllegalStateException if the key is not present in the context
+ */
+inline fun <reified T> FlippingExecutionContext.getOrThrow(key: String): T = get<T>(key) ?: error("To work with ${this::class.simpleName} you must provide '$key' parameter in execution context")

--- a/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/strategy/AllowListStrategy.kt
+++ b/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/strategy/AllowListStrategy.kt
@@ -4,6 +4,7 @@ import com.yonatankarp.ff4k.core.ContextKeys
 import com.yonatankarp.ff4k.core.FeatureStore
 import com.yonatankarp.ff4k.core.FlippingExecutionContext
 import com.yonatankarp.ff4k.core.FlippingStrategy
+import com.yonatankarp.ff4k.core.getOrThrow
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -11,9 +12,11 @@ import kotlinx.serialization.Serializable
  * A strategy that enables a feature only for users in an allowed list.
  *
  * Requires [ContextKeys.USER_ID] to be set in the [FlippingExecutionContext].
- * Returns `false` if no user ID is present or the list is empty.
+ * Throws [IllegalStateException] if no user ID is present.
+ * Returns `false` if the list is empty.
  *
  * @property allowedList The set of user IDs for whom the feature is enabled.
+ * @throws IllegalStateException if [ContextKeys.USER_ID] is not present in the context
  */
 @Serializable
 @SerialName("allowList")
@@ -27,7 +30,7 @@ data class AllowListStrategy(
     ): Boolean {
         if (allowedList.isEmpty()) return false
 
-        val userId = context.get<String>(ContextKeys.USER_ID) ?: return false
+        val userId = context.getOrThrow<String>(ContextKeys.USER_ID)
         return userId in allowedList
     }
 }

--- a/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/strategy/UserPonderationStrategy.kt
+++ b/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/strategy/UserPonderationStrategy.kt
@@ -4,6 +4,7 @@ import com.yonatankarp.ff4k.core.ContextKeys
 import com.yonatankarp.ff4k.core.FeatureStore
 import com.yonatankarp.ff4k.core.FlippingExecutionContext
 import com.yonatankarp.ff4k.core.FlippingStrategy
+import com.yonatankarp.ff4k.core.getOrThrow
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -15,9 +16,10 @@ import kotlinx.serialization.Serializable
  * on their user ID hash.
  *
  * Requires [ContextKeys.USER_ID] to be set in the [FlippingExecutionContext].
- * Returns `false` if no user ID is present.
+ * Throws [IllegalStateException] if no user ID is present.
  *
  * @property weight The percentage of users (0.0 to 1.0) for whom the feature is enabled.
+ * @throws IllegalStateException if [ContextKeys.USER_ID] is not present in the context
  * @see PonderationStrategy
  */
 @Serializable
@@ -37,7 +39,7 @@ data class UserPonderationStrategy(
         store: FeatureStore?,
         context: FlippingExecutionContext,
     ): Boolean {
-        val userId = context.get<String>(ContextKeys.USER_ID) ?: return false
+        val userId = context.getOrThrow<String>(ContextKeys.USER_ID)
 
         val bucket = (userId.hash() and 0x7FFFFFFF) % 100 // 0-99
         val threshold = (weight * 100).toInt()

--- a/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/core/FlippingExecutionContextsTest.kt
+++ b/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/core/FlippingExecutionContextsTest.kt
@@ -1,5 +1,6 @@
 package com.yonatankarp.ff4k.core
 
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.booleans.shouldBeFalse
 import io.kotest.matchers.booleans.shouldBeTrue
@@ -188,6 +189,45 @@ internal class FlippingExecutionContextsTest :
 
             // Then
             context.key shouldBe FlippingExecutionContext.Key
+        }
+
+        // ========== getOrThrow Tests ==========
+
+        test("getOrThrow should return value when key exists") {
+            // Given
+            val context = FlippingExecutionContext(ContextKeys.USER_ID to ALICE_USER_ID)
+
+            // When
+            val result: String = context.getOrThrow(ContextKeys.USER_ID)
+
+            // Then
+            result shouldBe ALICE_USER_ID
+        }
+
+        test("getOrThrow should throw IllegalStateException when key is missing") {
+            // Given
+            val context = FlippingExecutionContext()
+
+            // When/Then
+            shouldThrow<IllegalStateException> {
+                context.getOrThrow<String>(ContextKeys.USER_ID)
+            }.message shouldBe "To work with FlippingExecutionContext you must provide '${ContextKeys.USER_ID}' parameter in execution context"
+        }
+
+        test("getOrThrow should work with different types") {
+            // Given
+            val context = FlippingExecutionContext(
+                ContextKeys.USER_ID to ALICE_USER_ID,
+                REQUEST_COUNT_KEY to REQUEST_COUNT,
+            )
+
+            // When
+            val userId: String = context.getOrThrow(ContextKeys.USER_ID)
+            val count: Int = context.getOrThrow(REQUEST_COUNT_KEY)
+
+            // Then
+            userId shouldBe ALICE_USER_ID
+            count shouldBe REQUEST_COUNT
         }
     }) {
     companion object {

--- a/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/strategy/AllowListStrategyTest.kt
+++ b/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/strategy/AllowListStrategyTest.kt
@@ -6,9 +6,11 @@ import com.yonatankarp.ff4k.core.FlippingStrategy
 import com.yonatankarp.ff4k.serialization.FF4kJson
 import com.yonatankarp.ff4k.store.InMemoryFeatureStore
 import com.yonatankarp.ff4k.test.contract.strategy.FlippingStrategyContractTest
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.booleans.shouldBeFalse
 import io.kotest.matchers.booleans.shouldBeTrue
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
 import kotlinx.serialization.encodeToString
 
 internal class AllowListStrategyTest :
@@ -28,17 +30,16 @@ internal class AllowListStrategyTest :
                 result.shouldBeFalse()
             }
 
-            test("returns false when user ID is missing from context") {
+            test("throws IllegalStateException when user ID is missing from context") {
                 // Given
                 val strategy = AllowListStrategy(setOf("Alice", "Bob"))
                 val store = InMemoryFeatureStore()
                 val context = FlippingExecutionContext()
 
-                // When
-                val result = strategy.evaluate("test", store, context)
-
-                // Then
-                result.shouldBeFalse()
+                // When/Then
+                shouldThrow<IllegalStateException> {
+                    strategy.evaluate("test", store, context)
+                }.message shouldContain ContextKeys.USER_ID
             }
 
             test("returns true only for users in the allow list") {

--- a/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/strategy/UserPonderationStrategyTest.kt
+++ b/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/strategy/UserPonderationStrategyTest.kt
@@ -10,6 +10,7 @@ import io.kotest.matchers.booleans.shouldBeFalse
 import io.kotest.matchers.booleans.shouldBeTrue
 import io.kotest.matchers.doubles.shouldBeBetween
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
 
 internal class UserPonderationStrategyTest :
     FlippingStrategyContractTest({
@@ -72,6 +73,18 @@ internal class UserPonderationStrategyTest :
                         FlippingExecutionContext(ContextKeys.USER_ID to "user$userId")
                     strategy.evaluate("test", store, context).shouldBeFalse()
                 }
+            }
+
+            test("throws IllegalStateException when user ID is missing from context") {
+                // Given
+                val strategy = UserPonderationStrategy(0.5)
+                val store = InMemoryFeatureStore()
+                val context = FlippingExecutionContext()
+
+                // When/Then
+                shouldThrow<IllegalStateException> {
+                    strategy.evaluate("test", store, context)
+                }.message shouldContain ContextKeys.USER_ID
             }
         }
 


### PR DESCRIPTION
## Summary

<!-- Brief description of the changes (1-3 sentences) -->

Add `getOrThrow` extension function for FlippingExecutionContext that retrieves required parameters or throws `IllegalStateException` with a descriptive message. Update context-dependent strategies to use this function instead of silently returning false when required parameters are missing.

## Motivation

When strategies silently return false for missing context parameters, it can be difficult to debug why a feature flag isn't working as expected. Throwing an explicit exception makes misconfiguration immediately visible and provides actionable error messages. 

## Changes

<!-- What does this PR do? List the main changes -->

  - Add getOrThrow<T>(key) extension function to FlippingExecutionContext with KDoc                                                                                                                                                      
  - Add CLIENT_HOSTNAME constant to ContextKeys                                                                                                                                                                                          
  - Update AllowListStrategy to throw when USER_ID is missing                                                                                                                                                                            
  - Update UserPonderationStrategy to throw when USER_ID is missing                                                                                                                                                                      
  - Add ClientFilterStrategy that throws when CLIENT_HOSTNAME is missing                                                                                                                                                                 
  - Add unit tests for getOrThrow function                                                                                                                                                                                               
  - Update strategy tests to expect IllegalStateException     

## Testing

<!-- How did you test these changes? -->

- [x] Unit tests added/updated
- [x] Tested on JVM
- [x] Tested on Android
- [x] Tested on iOS

## Checklist

- [x] My code follows the project's code style (`./gradlew spotlessCheck` passes)
- [x] I have added tests that prove my fix/feature works
- [x] All tests pass (`./gradlew check`)
- [x] I have updated documentation if needed
- [ ] I marked all checkboxes without reading


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `getOrThrow` utility function to provide strict key retrieval from execution contexts with descriptive error messages.

* **Bug Fixes**
  * Improved error handling in strategy evaluation—missing required context keys now throw explicit exceptions instead of silently failing, enabling earlier detection of configuration issues.

* **Tests**
  * Added comprehensive test coverage for the new utility and updated existing tests to validate exception-throwing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->