### PR TITLE
feat(core): add client, server, and region filter strategies

### DIFF
--- a/docs/usage/strategies.md
+++ b/docs/usage/strategies.md
@@ -21,6 +21,8 @@ FF4K provides standard keys in `ContextKeys` for common parameters such as:
 - `ContextKeys.USER_NAME` ("userName"): User's display name.
 - `ContextKeys.REGION` ("region"): Geographic region (e.g., "EU", "US").
 - `ContextKeys.ENVIRONMENT` ("environment"): App environment (e.g., "prod", "staging").
+- `ContextKeys.CLIENT_HOSTNAME` ("clientHostname"): Client hostname making the request.
+- `ContextKeys.SERVER_HOSTNAME` ("serverHostname"): Server hostname handling the request.
 
 ```kotlin
 val context = FlippingExecutionContext(
@@ -112,6 +114,66 @@ feature("new-ui") {
         +"problematic-user-2"
     }
 }
+```
+
+## Filter Strategies
+
+### ClientFilterStrategy
+
+Enables a feature only for requests from specific client hostnames.
+
+Requires `ContextKeys.CLIENT_HOSTNAME` in the execution context.
+
+```kotlin
+feature("internal-only") {
+    clientFilterStrategy {
+        +"client-a.internal.com"
+        +"client-b.internal.com"
+    }
+}
+
+// Checking with client context
+val context = FlippingExecutionContext(ContextKeys.CLIENT_HOSTNAME to request.hostname)
+ff4k.check("internal-only", context)
+```
+
+### ServerFilterStrategy
+
+Enables a feature only on specific server hostnames. Useful for canary deployments or
+testing features on specific server instances.
+
+Requires `ContextKeys.SERVER_HOSTNAME` in the execution context.
+
+```kotlin
+feature("canary-feature") {
+    serverFilterStrategy {
+        +"server-1.prod.com"
+        +"server-2.prod.com"
+    }
+}
+
+// Checking with server context
+val context = FlippingExecutionContext(ContextKeys.SERVER_HOSTNAME to System.getenv("HOSTNAME"))
+ff4k.check("canary-feature", context)
+```
+
+### RegionFilterStrategy
+
+Enables a feature only for specific geographic regions.
+
+Requires `ContextKeys.REGION` in the execution context.
+
+```kotlin
+feature("eu-only") {
+    regionStrategy {
+        +"eu-central-1"
+        +"eu-west-1"
+    }
+}
+
+// Checking with region context
+val context = FlippingExecutionContext(ContextKeys.REGION to currentRegion)
+ff4k.check("eu-only", context)
 ```
 
 ## Time-Based Strategies

--- a/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/core/ContextKeys.kt
+++ b/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/core/ContextKeys.kt
@@ -42,4 +42,17 @@ object ContextKeys {
      * Useful for environment-specific feature toggles.
      */
     const val ENVIRONMENT = "environment"
+
+    /**
+     * Key for the client hostname making the request.
+     * Used by [ClientFilterStrategy] for client-based feature filtering.
+     */
+    const val CLIENT_HOSTNAME = "clientHostname"
+
+    /**
+     * Key for the server hostname handling the request.
+     * Used by [ServerFilterStrategy] for server-based feature filtering,
+     * useful for canary deployments or instance-specific features.
+     */
+    const val SERVER_HOSTNAME = "serverHostname"
 }

--- a/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/core/FlippingExecutionContexts.kt
+++ b/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/core/FlippingExecutionContexts.kt
@@ -166,4 +166,4 @@ suspend fun currentFlippingContext(): FlippingExecutionContext = currentCoroutin
  * @return The value associated with the key, cast to type [T]
  * @throws IllegalStateException if the key is not present in the context
  */
-inline fun <reified T> FlippingExecutionContext.getOrThrow(key: String): T = get<T>(key) ?: error("To work with ${this::class.simpleName} you must provide '$key' parameter in execution context")
+inline fun <reified T> FlippingExecutionContext.getOrThrow(key: String): T = get<T>(key) ?: error("${this::class.simpleName} requires '$key' parameter in execution context to work with this strategy")

--- a/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/dsl/strategy/ListBuilder.kt
+++ b/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/dsl/strategy/ListBuilder.kt
@@ -1,0 +1,58 @@
+package com.yonatankarp.ff4k.dsl.strategy
+
+import com.yonatankarp.ff4k.dsl.core.FF4kDsl
+
+/**
+ * DSL builder for constructing a set of identifiers used by list-based strategies.
+ *
+ * Provides multiple ways to add identifiers:
+ * - Unary plus operator: `+"identifier"`
+ * - [add] function: `add("identifier")`
+ * - [addAll] function: `addAll("id1", "id2", "id3")`
+ *
+ * @see allowListStrategy
+ * @see denyListStrategy
+ * @see clientFilterStrategy
+ * @see serverFilterStrategy
+ * @see regionStrategy
+ */
+@FF4kDsl
+class ListBuilder {
+    private val identifiers = mutableSetOf<String>()
+
+    /**
+     * Adds this string as an identifier to the list.
+     *
+     * ## Example
+     *
+     * ```kotlin
+     * allowListStrategy {
+     *     +"user-123"
+     *     +"user-456"
+     * }
+     * ```
+     */
+    operator fun String.unaryPlus() {
+        identifiers.add(this)
+    }
+
+    /**
+     * Adds an identifier to the list.
+     *
+     * @param identifier The identifier to add.
+     */
+    fun add(identifier: String) {
+        identifiers.add(identifier)
+    }
+
+    /**
+     * Adds multiple identifiers to the list.
+     *
+     * @param identifiers The identifiers to add.
+     */
+    fun addAll(vararg identifiers: String) {
+        this.identifiers.addAll(identifiers)
+    }
+
+    internal fun build(): Set<String> = identifiers.toSet()
+}

--- a/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/dsl/strategy/StrategyDsl.kt
+++ b/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/dsl/strategy/StrategyDsl.kt
@@ -1,16 +1,17 @@
 package com.yonatankarp.ff4k.dsl.strategy
 
-import com.yonatankarp.ff4k.dsl.core.FF4kDsl
 import com.yonatankarp.ff4k.dsl.feature.FeatureBuilder
 import com.yonatankarp.ff4k.strategy.AllowListStrategy
+import com.yonatankarp.ff4k.strategy.ClientFilterStrategy
 import com.yonatankarp.ff4k.strategy.DailyHoursStrategy
 import com.yonatankarp.ff4k.strategy.DateRangeStrategy
 import com.yonatankarp.ff4k.strategy.DenyListStrategy
 import com.yonatankarp.ff4k.strategy.PonderationStrategy
+import com.yonatankarp.ff4k.strategy.RegionFilterStrategy
 import com.yonatankarp.ff4k.strategy.ReleaseDateStrategy
+import com.yonatankarp.ff4k.strategy.ServerFilterStrategy
 import com.yonatankarp.ff4k.strategy.UserPonderationStrategy
 import com.yonatankarp.ff4k.strategy.WeekdayStrategy
-import kotlinx.datetime.DayOfWeek
 import kotlinx.datetime.Instant
 import kotlinx.datetime.LocalDateTime
 import kotlinx.datetime.TimeZone
@@ -383,164 +384,89 @@ fun FeatureBuilder.weekdayStrategy(
 }
 
 /**
- * DSL builder for constructing a set of [DayOfWeek] used by [WeekdayStrategy].
+ * Configures a [ClientFilterStrategy] for this feature.
  *
- * Provides multiple ways to add days:
- * - Unary plus operator: `+DayOfWeek.MONDAY`
- * - [add] function: `add(DayOfWeek.MONDAY)`
- * - [addAll] function: `addAll(DayOfWeek.MONDAY, DayOfWeek.FRIDAY)`
- * - Convenience functions: [weekdays], [weekends], [allDays]
+ * The feature will be enabled only for requests from the specified client
+ * hostnames. Requires [com.yonatankarp.ff4k.core.ContextKeys.CLIENT_HOSTNAME]
+ * to be set in the [com.yonatankarp.ff4k.core.FlippingExecutionContext].
  *
- * @see weekdayStrategy
+ * ## Example
+ *
+ * ```kotlin
+ * feature("internal-only") {
+ *     clientFilterStrategy {
+ *         +"client-a.internal.com"
+ *         +"client-b.internal.com"
+ *     }
+ * }
+ * ```
+ *
+ * @param block A DSL block to configure the set of allowed client hostnames.
+ * @see serverFilterStrategy
+ * @see regionStrategy
  */
-@FF4kDsl
-class WeekdayBuilder {
-    private val days = mutableSetOf<DayOfWeek>()
-
-    /**
-     * Adds this day to the allowed days.
-     *
-     * ## Example
-     *
-     * ```kotlin
-     * weekdayStrategy {
-     *     +DayOfWeek.MONDAY
-     *     +DayOfWeek.FRIDAY
-     * }
-     * ```
-     */
-    operator fun DayOfWeek.unaryPlus() {
-        days.add(this)
-    }
-
-    /**
-     * Adds a day to the allowed days.
-     *
-     * @param day The day to add.
-     */
-    fun add(day: DayOfWeek) {
-        days.add(day)
-    }
-
-    /**
-     * Adds multiple days to the allowed days.
-     *
-     * @param days The days to add.
-     */
-    fun addAll(vararg days: DayOfWeek) {
-        this.days.addAll(days)
-    }
-
-    /**
-     * Adds all weekdays (Monday through Friday) to the allowed days.
-     *
-     * ## Example
-     *
-     * ```kotlin
-     * feature("workday-feature") {
-     *     weekdayStrategy {
-     *         weekdays() // Monday through Friday
-     *     }
-     * }
-     * ```
-     */
-    fun weekdays() {
-        days.addAll(
-            listOf(
-                DayOfWeek.MONDAY,
-                DayOfWeek.TUESDAY,
-                DayOfWeek.WEDNESDAY,
-                DayOfWeek.THURSDAY,
-                DayOfWeek.FRIDAY,
-            ),
-        )
-    }
-
-    /**
-     * Adds weekend days (Saturday and Sunday) to the allowed days.
-     *
-     * ## Example
-     *
-     * ```kotlin
-     * feature("weekend-promo") {
-     *     weekdayStrategy {
-     *         weekends() // Saturday and Sunday
-     *     }
-     * }
-     * ```
-     */
-    fun weekends() {
-        days.addAll(listOf(DayOfWeek.SATURDAY, DayOfWeek.SUNDAY))
-    }
-
-    /**
-     * Adds all days of the week to the allowed days.
-     *
-     * ## Example
-     *
-     * ```kotlin
-     * feature("always-available") {
-     *     weekdayStrategy {
-     *         allDays() // All seven days
-     *     }
-     * }
-     * ```
-     */
-    fun allDays() {
-        days.addAll(DayOfWeek.entries)
-    }
-
-    internal fun build(): Set<DayOfWeek> = days.toSet()
+fun FeatureBuilder.clientFilterStrategy(
+    block: ListBuilder.() -> Unit,
+) {
+    val grantedClients = ListBuilder().apply(block).build()
+    flippingStrategy = ClientFilterStrategy(grantedClients)
 }
 
 /**
- * DSL builder for constructing a set of identifiers used by list-based strategies.
+ * Configures a [ServerFilterStrategy] for this feature.
  *
- * Provides multiple ways to add identifiers:
- * - Unary plus operator: `+"identifier"`
- * - [add] function: `add("identifier")`
- * - [addAll] function: `addAll("id1", "id2", "id3")`
+ * The feature will be enabled only on the specified server hostnames.
+ * Useful for canary deployments or instance-specific feature toggles.
+ * Requires [com.yonatankarp.ff4k.core.ContextKeys.SERVER_HOSTNAME]
+ * to be set in the [com.yonatankarp.ff4k.core.FlippingExecutionContext].
  *
- * @see allowListStrategy
- * @see denyListStrategy
+ * ## Example
+ *
+ * ```kotlin
+ * feature("canary-feature") {
+ *     serverFilterStrategy {
+ *         +"server-1.prod.com"
+ *         +"server-2.prod.com"
+ *     }
+ * }
+ * ```
+ *
+ * @param block A DSL block to configure the set of target server hostnames.
+ * @see clientFilterStrategy
+ * @see regionStrategy
  */
-@FF4kDsl
-class ListBuilder {
-    private val identifiers = mutableSetOf<String>()
+fun FeatureBuilder.serverFilterStrategy(
+    block: ListBuilder.() -> Unit,
+) {
+    val targetServers = ListBuilder().apply(block).build()
+    flippingStrategy = ServerFilterStrategy(targetServers)
+}
 
-    /**
-     * Adds this string as an identifier to the list.
-     *
-     * ## Example
-     *
-     * ```kotlin
-     * allowListStrategy {
-     *     +"user-123"
-     *     +"user-456"
-     * }
-     * ```
-     */
-    operator fun String.unaryPlus() {
-        identifiers.add(this)
-    }
-
-    /**
-     * Adds an identifier to the list.
-     *
-     * @param identifier The identifier to add.
-     */
-    fun add(identifier: String) {
-        identifiers.add(identifier)
-    }
-
-    /**
-     * Adds multiple identifiers to the list.
-     *
-     * @param identifiers The identifiers to add.
-     */
-    fun addAll(vararg identifiers: String) {
-        this.identifiers.addAll(identifiers)
-    }
-
-    internal fun build(): Set<String> = identifiers.toSet()
+/**
+ * Configures a [RegionFilterStrategy] for this feature.
+ *
+ * The feature will be enabled only for the specified geographic regions.
+ * Requires [com.yonatankarp.ff4k.core.ContextKeys.REGION] to be set in the
+ * [com.yonatankarp.ff4k.core.FlippingExecutionContext].
+ *
+ * ## Example
+ *
+ * ```kotlin
+ * feature("eu-only") {
+ *     regionStrategy {
+ *         +"eu-central-1"
+ *         +"eu-west-1"
+ *     }
+ * }
+ * ```
+ *
+ * @param block A DSL block to configure the set of allowed regions.
+ * @see clientFilterStrategy
+ * @see serverFilterStrategy
+ */
+fun FeatureBuilder.regionStrategy(
+    block: ListBuilder.() -> Unit,
+) {
+    val allowedRegions = ListBuilder().apply(block).build()
+    flippingStrategy = RegionFilterStrategy(allowedRegions)
 }

--- a/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/dsl/strategy/WeekdayBuilder.kt
+++ b/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/dsl/strategy/WeekdayBuilder.kt
@@ -1,0 +1,116 @@
+package com.yonatankarp.ff4k.dsl.strategy
+
+import com.yonatankarp.ff4k.dsl.core.FF4kDsl
+import com.yonatankarp.ff4k.strategy.WeekdayStrategy
+import kotlinx.datetime.DayOfWeek
+
+/**
+ * DSL builder for constructing a set of [DayOfWeek] used by [WeekdayStrategy].
+ *
+ * Provides multiple ways to add days:
+ * - Unary plus operator: `+DayOfWeek.MONDAY`
+ * - [add] function: `add(DayOfWeek.MONDAY)`
+ * - [addAll] function: `addAll(DayOfWeek.MONDAY, DayOfWeek.FRIDAY)`
+ * - Convenience functions: [weekdays], [weekends], [allDays]
+ *
+ * @see weekdayStrategy
+ */
+@FF4kDsl
+class WeekdayBuilder {
+    private val days = mutableSetOf<DayOfWeek>()
+
+    /**
+     * Adds this day to the allowed days.
+     *
+     * ## Example
+     *
+     * ```kotlin
+     * weekdayStrategy {
+     *     +DayOfWeek.MONDAY
+     *     +DayOfWeek.FRIDAY
+     * }
+     * ```
+     */
+    operator fun DayOfWeek.unaryPlus() {
+        days.add(this)
+    }
+
+    /**
+     * Adds a day to the allowed days.
+     *
+     * @param day The day to add.
+     */
+    fun add(day: DayOfWeek) {
+        days.add(day)
+    }
+
+    /**
+     * Adds multiple days to the allowed days.
+     *
+     * @param days The days to add.
+     */
+    fun addAll(vararg days: DayOfWeek) {
+        this.days.addAll(days)
+    }
+
+    /**
+     * Adds all weekdays (Monday through Friday) to the allowed days.
+     *
+     * ## Example
+     *
+     * ```kotlin
+     * feature("workday-feature") {
+     *     weekdayStrategy {
+     *         weekdays() // Monday through Friday
+     *     }
+     * }
+     * ```
+     */
+    fun weekdays() {
+        days.addAll(
+            listOf(
+                DayOfWeek.MONDAY,
+                DayOfWeek.TUESDAY,
+                DayOfWeek.WEDNESDAY,
+                DayOfWeek.THURSDAY,
+                DayOfWeek.FRIDAY,
+            ),
+        )
+    }
+
+    /**
+     * Adds weekend days (Saturday and Sunday) to the allowed days.
+     *
+     * ## Example
+     *
+     * ```kotlin
+     * feature("weekend-promo") {
+     *     weekdayStrategy {
+     *         weekends() // Saturday and Sunday
+     *     }
+     * }
+     * ```
+     */
+    fun weekends() {
+        days.addAll(listOf(DayOfWeek.SATURDAY, DayOfWeek.SUNDAY))
+    }
+
+    /**
+     * Adds all days of the week to the allowed days.
+     *
+     * ## Example
+     *
+     * ```kotlin
+     * feature("always-available") {
+     *     weekdayStrategy {
+     *         allDays() // All seven days
+     *     }
+     * }
+     * ```
+     */
+    fun allDays() {
+        days.addAll(DayOfWeek.entries)
+    }
+
+    internal fun build(): Set<DayOfWeek> = days.toSet()
+}

--- a/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/serialization/FF4kSerializersModule.kt
+++ b/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/serialization/FF4kSerializersModule.kt
@@ -21,13 +21,16 @@ import com.yonatankarp.ff4k.strategy.AllowListStrategy
 import com.yonatankarp.ff4k.strategy.AlwaysFalseFlippingStrategy
 import com.yonatankarp.ff4k.strategy.AlwaysTrueFlippingStrategy
 import com.yonatankarp.ff4k.strategy.AndStrategy
+import com.yonatankarp.ff4k.strategy.ClientFilterStrategy
 import com.yonatankarp.ff4k.strategy.DailyHoursStrategy
 import com.yonatankarp.ff4k.strategy.DateRangeStrategy
 import com.yonatankarp.ff4k.strategy.DenyListStrategy
 import com.yonatankarp.ff4k.strategy.NotStrategy
 import com.yonatankarp.ff4k.strategy.OrStrategy
 import com.yonatankarp.ff4k.strategy.PonderationStrategy
+import com.yonatankarp.ff4k.strategy.RegionFilterStrategy
 import com.yonatankarp.ff4k.strategy.ReleaseDateStrategy
+import com.yonatankarp.ff4k.strategy.ServerFilterStrategy
 import com.yonatankarp.ff4k.strategy.UserPonderationStrategy
 import com.yonatankarp.ff4k.strategy.WeekdayStrategy
 import kotlinx.serialization.json.Json
@@ -67,6 +70,9 @@ val ff4kSerializersModule = SerializersModule {
         subclass(DateRangeStrategy::class, DateRangeStrategy.serializer())
         subclass(DailyHoursStrategy::class, DailyHoursStrategy.serializer())
         subclass(WeekdayStrategy::class, WeekdayStrategy.serializer())
+        subclass(RegionFilterStrategy::class, RegionFilterStrategy.serializer())
+        subclass(ClientFilterStrategy::class, ClientFilterStrategy.serializer())
+        subclass(ServerFilterStrategy::class, ServerFilterStrategy.serializer())
     }
 } + humanReadableSerializerModule
 

--- a/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/strategy/ClientFilterStrategy.kt
+++ b/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/strategy/ClientFilterStrategy.kt
@@ -1,0 +1,41 @@
+package com.yonatankarp.ff4k.strategy
+
+import com.yonatankarp.ff4k.core.ContextKeys
+import com.yonatankarp.ff4k.core.FeatureStore
+import com.yonatankarp.ff4k.core.FlippingExecutionContext
+import com.yonatankarp.ff4k.core.FlippingStrategy
+import com.yonatankarp.ff4k.core.getOrThrow
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * A strategy that enables a feature only for requests from specific client hostnames.
+ *
+ * Requires [ContextKeys.CLIENT_HOSTNAME] to be set in the [FlippingExecutionContext].
+ * Throws [IllegalStateException] if no client hostname is present.
+ *
+ * An empty [grantedClients] set means that no clients are granted access and this
+ * strategy will always evaluate to `false`. This matches the behavior of other
+ * filter-style strategies (e.g. [AllowListStrategy]) where an empty list denies all.
+ *
+ * @property grantedClients The set of client hostnames for which the feature is enabled.
+ *                          If empty, the feature is disabled for all clients.
+ * @throws IllegalStateException if [ContextKeys.CLIENT_HOSTNAME] is not present in the context
+ */
+@Serializable
+@SerialName("clientFilter")
+data class ClientFilterStrategy(
+    val grantedClients: Set<String> = emptySet(),
+) : FlippingStrategy {
+
+    constructor(vararg clients: String) : this(clients.toSet())
+
+    override suspend fun evaluate(
+        featureId: String,
+        store: FeatureStore?,
+        context: FlippingExecutionContext,
+    ): Boolean {
+        val client = context.getOrThrow<String>(ContextKeys.CLIENT_HOSTNAME)
+        return client in grantedClients
+    }
+}

--- a/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/strategy/RegionFilterStrategy.kt
+++ b/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/strategy/RegionFilterStrategy.kt
@@ -1,0 +1,40 @@
+package com.yonatankarp.ff4k.strategy
+
+import com.yonatankarp.ff4k.core.ContextKeys
+import com.yonatankarp.ff4k.core.FeatureStore
+import com.yonatankarp.ff4k.core.FlippingExecutionContext
+import com.yonatankarp.ff4k.core.FlippingStrategy
+import com.yonatankarp.ff4k.core.getOrThrow
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * A strategy that enables a feature only for specific geographic regions.
+ *
+ * Requires [ContextKeys.REGION] to be set in the [FlippingExecutionContext].
+ * Throws [IllegalStateException] if no region is present.
+ *
+ * An empty [grantedRegions] set means that the feature is disabled for all regions
+ * (i.e. [evaluate] will always return `false` as long as a region is present).
+ *
+ * @property grantedRegions The set of regions (e.g., "EU", "US", "APAC") for which the feature is enabled.
+ *                           If this set is empty, no regions are granted access.
+ * @throws IllegalStateException if [ContextKeys.REGION] is not present in the context
+ */
+@Serializable
+@SerialName("region")
+data class RegionFilterStrategy(
+    val grantedRegions: Set<String> = emptySet(),
+) : FlippingStrategy {
+
+    constructor(vararg allowedRegions: String) : this(allowedRegions.toSet())
+
+    override suspend fun evaluate(
+        featureId: String,
+        store: FeatureStore?,
+        context: FlippingExecutionContext,
+    ): Boolean {
+        val region = context.getOrThrow<String>(ContextKeys.REGION)
+        return region in grantedRegions
+    }
+}

--- a/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/strategy/ServerFilterStrategy.kt
+++ b/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/strategy/ServerFilterStrategy.kt
@@ -1,0 +1,41 @@
+package com.yonatankarp.ff4k.strategy
+
+import com.yonatankarp.ff4k.core.ContextKeys
+import com.yonatankarp.ff4k.core.FeatureStore
+import com.yonatankarp.ff4k.core.FlippingExecutionContext
+import com.yonatankarp.ff4k.core.FlippingStrategy
+import com.yonatankarp.ff4k.core.getOrThrow
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * A strategy that enables a feature only on specific server hostnames.
+ *
+ * Useful for canary deployments or testing features on specific server instances.
+ * Requires [ContextKeys.SERVER_HOSTNAME] to be set in the [FlippingExecutionContext].
+ * Throws [IllegalStateException] if no server hostname is present.
+ *
+ * Note: If [targetServers] is empty (the default), no servers are granted access and this
+ * strategy will always return `false` for any server hostname.
+ *
+ * @property targetServers The set of server hostnames on which the feature is enabled.
+ * If this set is empty, the feature is disabled for all servers.
+ * @throws IllegalStateException if [ContextKeys.SERVER_HOSTNAME] is not present in the context
+ */
+@Serializable
+@SerialName("serverFilter")
+data class ServerFilterStrategy(
+    val targetServers: Set<String> = emptySet(),
+) : FlippingStrategy {
+
+    constructor(vararg servers: String) : this(servers.toSet())
+
+    override suspend fun evaluate(
+        featureId: String,
+        store: FeatureStore?,
+        context: FlippingExecutionContext,
+    ): Boolean {
+        val server = context.getOrThrow<String>(ContextKeys.SERVER_HOSTNAME)
+        return server in targetServers
+    }
+}

--- a/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/core/FlippingExecutionContextsTest.kt
+++ b/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/core/FlippingExecutionContextsTest.kt
@@ -211,7 +211,7 @@ internal class FlippingExecutionContextsTest :
             // When/Then
             shouldThrow<IllegalStateException> {
                 context.getOrThrow<String>(ContextKeys.USER_ID)
-            }.message shouldBe "To work with FlippingExecutionContext you must provide '${ContextKeys.USER_ID}' parameter in execution context"
+            }
         }
 
         test("getOrThrow should work with different types") {

--- a/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/dsl/strategy/ListBuilderTest.kt
+++ b/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/dsl/strategy/ListBuilderTest.kt
@@ -1,0 +1,61 @@
+package com.yonatankarp.ff4k.dsl.strategy
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.shouldBe
+
+internal class ListBuilderTest :
+    FunSpec({
+
+        test("unary plus operator adds identifiers") {
+            val result = ListBuilder().apply {
+                +"id-1"
+                +"id-2"
+            }.build()
+
+            result shouldContainExactlyInAnyOrder listOf("id-1", "id-2")
+        }
+
+        test("add function adds identifier") {
+            val result = ListBuilder().apply {
+                add("id-1")
+                add("id-2")
+            }.build()
+
+            result shouldContainExactlyInAnyOrder listOf("id-1", "id-2")
+        }
+
+        test("addAll function adds multiple identifiers") {
+            val result = ListBuilder().apply {
+                addAll("id-1", "id-2", "id-3")
+            }.build()
+
+            result shouldContainExactlyInAnyOrder listOf("id-1", "id-2", "id-3")
+        }
+
+        test("mixed methods work together") {
+            val result = ListBuilder().apply {
+                +"id-1"
+                add("id-2")
+                addAll("id-3", "id-4")
+            }.build()
+
+            result shouldContainExactlyInAnyOrder listOf("id-1", "id-2", "id-3", "id-4")
+        }
+
+        test("deduplicates entries") {
+            val result = ListBuilder().apply {
+                +"id-1"
+                +"id-1"
+                add("id-1")
+            }.build()
+
+            result shouldBe setOf("id-1")
+        }
+
+        test("empty builder produces empty set") {
+            val result = ListBuilder().build()
+
+            result shouldBe emptySet()
+        }
+    })

--- a/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/dsl/strategy/StrategyDslTest.kt
+++ b/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/dsl/strategy/StrategyDslTest.kt
@@ -2,11 +2,14 @@ package com.yonatankarp.ff4k.dsl.strategy
 
 import com.yonatankarp.ff4k.dsl.feature.feature
 import com.yonatankarp.ff4k.strategy.AllowListStrategy
+import com.yonatankarp.ff4k.strategy.ClientFilterStrategy
 import com.yonatankarp.ff4k.strategy.DailyHoursStrategy
 import com.yonatankarp.ff4k.strategy.DateRangeStrategy
 import com.yonatankarp.ff4k.strategy.DenyListStrategy
 import com.yonatankarp.ff4k.strategy.PonderationStrategy
+import com.yonatankarp.ff4k.strategy.RegionFilterStrategy
 import com.yonatankarp.ff4k.strategy.ReleaseDateStrategy
+import com.yonatankarp.ff4k.strategy.ServerFilterStrategy
 import com.yonatankarp.ff4k.strategy.UserPonderationStrategy
 import com.yonatankarp.ff4k.strategy.WeekdayStrategy
 import io.kotest.core.spec.style.FunSpec
@@ -58,130 +61,64 @@ internal class StrategyDslTest :
             feature.flippingStrategy.weight shouldBe 0.5
         }
 
-        context("allowListStrategy") {
-            test("sets AllowListStrategy with unary plus operator") {
-                val feature = feature("test") {
-                    allowListStrategy {
-                        +"user-1"
-                        +"user-2"
-                    }
+        test("allowListStrategy sets AllowListStrategy") {
+            val feature = feature("test") {
+                allowListStrategy {
+                    +"user-1"
+                    +"user-2"
                 }
-
-                feature.flippingStrategy.shouldBeInstanceOf<AllowListStrategy>()
-                feature.flippingStrategy.allowedList shouldContainExactlyInAnyOrder listOf("user-1", "user-2")
             }
 
-            test("sets AllowListStrategy with add function") {
-                val feature = feature("test") {
-                    allowListStrategy {
-                        add("user-1")
-                        add("user-2")
-                    }
-                }
-
-                feature.flippingStrategy.shouldBeInstanceOf<AllowListStrategy>()
-                feature.flippingStrategy.allowedList shouldContainExactlyInAnyOrder listOf("user-1", "user-2")
-            }
-
-            test("sets AllowListStrategy with addAll function") {
-                val feature = feature("test") {
-                    allowListStrategy {
-                        addAll("user-1", "user-2", "user-3")
-                    }
-                }
-
-                feature.flippingStrategy.shouldBeInstanceOf<AllowListStrategy>()
-                feature.flippingStrategy.allowedList shouldContainExactlyInAnyOrder listOf("user-1", "user-2", "user-3")
-            }
-
-            test("sets AllowListStrategy with mixed methods") {
-                val feature = feature("test") {
-                    allowListStrategy {
-                        +"user-1"
-                        add("user-2")
-                        addAll("user-3", "user-4")
-                    }
-                }
-
-                feature.flippingStrategy.shouldBeInstanceOf<AllowListStrategy>()
-                feature.flippingStrategy.allowedList shouldContainExactlyInAnyOrder listOf("user-1", "user-2", "user-3", "user-4")
-            }
-
-            test("deduplicates entries") {
-                val feature = feature("test") {
-                    allowListStrategy {
-                        +"user-1"
-                        +"user-1"
-                        add("user-1")
-                    }
-                }
-
-                feature.flippingStrategy.shouldBeInstanceOf<AllowListStrategy>()
-                feature.flippingStrategy.allowedList shouldBe setOf("user-1")
-            }
+            feature.flippingStrategy.shouldBeInstanceOf<AllowListStrategy>()
+            feature.flippingStrategy.allowedList shouldContainExactlyInAnyOrder listOf("user-1", "user-2")
         }
 
-        context("denyListStrategy") {
-            test("sets DenyListStrategy with unary plus operator") {
-                val feature = feature("test") {
-                    denyListStrategy {
-                        +"user-1"
-                        +"user-2"
-                    }
+        test("denyListStrategy sets DenyListStrategy") {
+            val feature = feature("test") {
+                denyListStrategy {
+                    +"user-1"
+                    +"user-2"
                 }
-
-                feature.flippingStrategy.shouldBeInstanceOf<DenyListStrategy>()
-                feature.flippingStrategy.denyList shouldContainExactlyInAnyOrder listOf("user-1", "user-2")
             }
 
-            test("sets DenyListStrategy with add function") {
-                val feature = feature("test") {
-                    denyListStrategy {
-                        add("user-1")
-                        add("user-2")
-                    }
-                }
+            feature.flippingStrategy.shouldBeInstanceOf<DenyListStrategy>()
+            feature.flippingStrategy.denyList shouldContainExactlyInAnyOrder listOf("user-1", "user-2")
+        }
 
-                feature.flippingStrategy.shouldBeInstanceOf<DenyListStrategy>()
-                feature.flippingStrategy.denyList shouldContainExactlyInAnyOrder listOf("user-1", "user-2")
+        test("clientFilterStrategy sets ClientFilterStrategy") {
+            val feature = feature("test") {
+                clientFilterStrategy {
+                    +"client-a"
+                    +"client-b"
+                }
             }
 
-            test("sets DenyListStrategy with addAll function") {
-                val feature = feature("test") {
-                    denyListStrategy {
-                        addAll("user-1", "user-2", "user-3")
-                    }
-                }
+            feature.flippingStrategy.shouldBeInstanceOf<ClientFilterStrategy>()
+            feature.flippingStrategy.grantedClients shouldContainExactlyInAnyOrder listOf("client-a", "client-b")
+        }
 
-                feature.flippingStrategy.shouldBeInstanceOf<DenyListStrategy>()
-                feature.flippingStrategy.denyList shouldContainExactlyInAnyOrder listOf("user-1", "user-2", "user-3")
+        test("serverFilterStrategy sets ServerFilterStrategy") {
+            val feature = feature("test") {
+                serverFilterStrategy {
+                    +"server-1"
+                    +"server-2"
+                }
             }
 
-            test("sets DenyListStrategy with mixed methods") {
-                val feature = feature("test") {
-                    denyListStrategy {
-                        +"user-1"
-                        add("user-2")
-                        addAll("user-3", "user-4")
-                    }
-                }
+            feature.flippingStrategy.shouldBeInstanceOf<ServerFilterStrategy>()
+            feature.flippingStrategy.targetServers shouldContainExactlyInAnyOrder listOf("server-1", "server-2")
+        }
 
-                feature.flippingStrategy.shouldBeInstanceOf<DenyListStrategy>()
-                feature.flippingStrategy.denyList shouldContainExactlyInAnyOrder listOf("user-1", "user-2", "user-3", "user-4")
+        test("regionStrategy sets RegionFilterStrategy") {
+            val feature = feature("test") {
+                regionStrategy {
+                    +"eu-central-1"
+                    +"us-west-2"
+                }
             }
 
-            test("deduplicates entries") {
-                val feature = feature("test") {
-                    denyListStrategy {
-                        +"user-1"
-                        +"user-1"
-                        add("user-1")
-                    }
-                }
-
-                feature.flippingStrategy.shouldBeInstanceOf<DenyListStrategy>()
-                feature.flippingStrategy.denyList shouldBe setOf("user-1")
-            }
+            feature.flippingStrategy.shouldBeInstanceOf<RegionFilterStrategy>()
+            feature.flippingStrategy.grantedRegions shouldContainExactlyInAnyOrder listOf("eu-central-1", "us-west-2")
         }
 
         context("releaseDateStrategy") {
@@ -277,98 +214,29 @@ internal class StrategyDslTest :
             }
         }
 
-        context("weekdayStrategy") {
-            test("sets WeekdayStrategy with unary plus operator") {
-                val timezone = TimeZone.of("Asia/Tokyo")
-                val feature = feature("test") {
-                    weekdayStrategy(timezone) {
-                        +DayOfWeek.MONDAY
-                        +DayOfWeek.FRIDAY
-                    }
+        test("weekdayStrategy sets WeekdayStrategy with timezone") {
+            val timezone = TimeZone.of("Asia/Tokyo")
+            val feature = feature("test") {
+                weekdayStrategy(timezone) {
+                    +DayOfWeek.MONDAY
+                    +DayOfWeek.FRIDAY
                 }
-
-                feature.flippingStrategy.shouldBeInstanceOf<WeekdayStrategy>()
-                val strategy = feature.flippingStrategy
-                strategy.allowedDays shouldContainExactlyInAnyOrder setOf(DayOfWeek.MONDAY, DayOfWeek.FRIDAY)
-                strategy.timezone shouldBe timezone
             }
 
-            test("sets WeekdayStrategy with add function") {
-                val feature = feature("test") {
-                    weekdayStrategy {
-                        add(DayOfWeek.TUESDAY)
-                        add(DayOfWeek.THURSDAY)
-                    }
-                }
+            feature.flippingStrategy.shouldBeInstanceOf<WeekdayStrategy>()
+            val strategy = feature.flippingStrategy
+            strategy.allowedDays shouldContainExactlyInAnyOrder setOf(DayOfWeek.MONDAY, DayOfWeek.FRIDAY)
+            strategy.timezone shouldBe timezone
+        }
 
-                feature.flippingStrategy.shouldBeInstanceOf<WeekdayStrategy>()
-                feature.flippingStrategy.allowedDays shouldContainExactlyInAnyOrder setOf(DayOfWeek.TUESDAY, DayOfWeek.THURSDAY)
+        test("weekdayStrategy defaults to UTC") {
+            val feature = feature("test") {
+                weekdayStrategy {
+                    +DayOfWeek.MONDAY
+                }
             }
 
-            test("sets WeekdayStrategy with addAll function") {
-                val feature = feature("test") {
-                    weekdayStrategy {
-                        addAll(DayOfWeek.SATURDAY, DayOfWeek.SUNDAY)
-                    }
-                }
-
-                feature.flippingStrategy.shouldBeInstanceOf<WeekdayStrategy>()
-                feature.flippingStrategy.allowedDays shouldContainExactlyInAnyOrder setOf(DayOfWeek.SATURDAY, DayOfWeek.SUNDAY)
-            }
-
-            test("sets WeekdayStrategy with weekdays() helper") {
-                val feature = feature("test") {
-                    weekdayStrategy {
-                        weekdays()
-                    }
-                }
-
-                feature.flippingStrategy.shouldBeInstanceOf<WeekdayStrategy>()
-                feature.flippingStrategy.allowedDays shouldContainExactlyInAnyOrder setOf(
-                    DayOfWeek.MONDAY,
-                    DayOfWeek.TUESDAY,
-                    DayOfWeek.WEDNESDAY,
-                    DayOfWeek.THURSDAY,
-                    DayOfWeek.FRIDAY,
-                )
-            }
-
-            test("sets WeekdayStrategy with weekends() helper") {
-                val feature = feature("test") {
-                    weekdayStrategy {
-                        weekends()
-                    }
-                }
-
-                feature.flippingStrategy.shouldBeInstanceOf<WeekdayStrategy>()
-                feature.flippingStrategy.allowedDays shouldContainExactlyInAnyOrder setOf(DayOfWeek.SATURDAY, DayOfWeek.SUNDAY)
-            }
-
-            test("sets WeekdayStrategy with allDays() helper") {
-                val feature = feature("test") {
-                    weekdayStrategy {
-                        allDays()
-                    }
-                }
-
-                feature.flippingStrategy.shouldBeInstanceOf<WeekdayStrategy>()
-                feature.flippingStrategy.allowedDays shouldContainExactlyInAnyOrder DayOfWeek.entries.toSet()
-            }
-
-            test("sets WeekdayStrategy with mixed methods") {
-                val feature = feature("test") {
-                    weekdayStrategy {
-                        +DayOfWeek.MONDAY
-                        weekends()
-                    }
-                }
-
-                feature.flippingStrategy.shouldBeInstanceOf<WeekdayStrategy>()
-                feature.flippingStrategy.allowedDays shouldContainExactlyInAnyOrder setOf(
-                    DayOfWeek.MONDAY,
-                    DayOfWeek.SATURDAY,
-                    DayOfWeek.SUNDAY,
-                )
-            }
+            feature.flippingStrategy.shouldBeInstanceOf<WeekdayStrategy>()
+            feature.flippingStrategy.timezone shouldBe TimeZone.UTC
         }
     })

--- a/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/dsl/strategy/WeekdayBuilderTest.kt
+++ b/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/dsl/strategy/WeekdayBuilderTest.kt
@@ -1,0 +1,95 @@
+package com.yonatankarp.ff4k.dsl.strategy
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.shouldBe
+import kotlinx.datetime.DayOfWeek
+
+internal class WeekdayBuilderTest :
+    FunSpec({
+
+        test("unary plus operator adds days") {
+            val result = WeekdayBuilder().apply {
+                +DayOfWeek.MONDAY
+                +DayOfWeek.FRIDAY
+            }.build()
+
+            result shouldContainExactlyInAnyOrder setOf(DayOfWeek.MONDAY, DayOfWeek.FRIDAY)
+        }
+
+        test("add function adds day") {
+            val result = WeekdayBuilder().apply {
+                add(DayOfWeek.TUESDAY)
+                add(DayOfWeek.THURSDAY)
+            }.build()
+
+            result shouldContainExactlyInAnyOrder setOf(DayOfWeek.TUESDAY, DayOfWeek.THURSDAY)
+        }
+
+        test("addAll function adds multiple days") {
+            val result = WeekdayBuilder().apply {
+                addAll(DayOfWeek.SATURDAY, DayOfWeek.SUNDAY)
+            }.build()
+
+            result shouldContainExactlyInAnyOrder setOf(DayOfWeek.SATURDAY, DayOfWeek.SUNDAY)
+        }
+
+        test("weekdays adds Monday through Friday") {
+            val result = WeekdayBuilder().apply {
+                weekdays()
+            }.build()
+
+            result shouldContainExactlyInAnyOrder setOf(
+                DayOfWeek.MONDAY,
+                DayOfWeek.TUESDAY,
+                DayOfWeek.WEDNESDAY,
+                DayOfWeek.THURSDAY,
+                DayOfWeek.FRIDAY,
+            )
+        }
+
+        test("weekends adds Saturday and Sunday") {
+            val result = WeekdayBuilder().apply {
+                weekends()
+            }.build()
+
+            result shouldContainExactlyInAnyOrder setOf(DayOfWeek.SATURDAY, DayOfWeek.SUNDAY)
+        }
+
+        test("allDays adds all seven days") {
+            val result = WeekdayBuilder().apply {
+                allDays()
+            }.build()
+
+            result shouldContainExactlyInAnyOrder DayOfWeek.entries.toSet()
+        }
+
+        test("mixed methods work together") {
+            val result = WeekdayBuilder().apply {
+                +DayOfWeek.MONDAY
+                weekends()
+            }.build()
+
+            result shouldContainExactlyInAnyOrder setOf(
+                DayOfWeek.MONDAY,
+                DayOfWeek.SATURDAY,
+                DayOfWeek.SUNDAY,
+            )
+        }
+
+        test("deduplicates entries") {
+            val result = WeekdayBuilder().apply {
+                +DayOfWeek.MONDAY
+                +DayOfWeek.MONDAY
+                add(DayOfWeek.MONDAY)
+            }.build()
+
+            result shouldBe setOf(DayOfWeek.MONDAY)
+        }
+
+        test("empty builder produces empty set") {
+            val result = WeekdayBuilder().build()
+
+            result shouldBe emptySet()
+        }
+    })

--- a/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/strategy/ClientFilterStrategyTest.kt
+++ b/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/strategy/ClientFilterStrategyTest.kt
@@ -1,0 +1,50 @@
+package com.yonatankarp.ff4k.strategy
+
+import com.yonatankarp.ff4k.core.ContextKeys
+import com.yonatankarp.ff4k.core.FlippingExecutionContext
+import com.yonatankarp.ff4k.core.FlippingStrategy
+import com.yonatankarp.ff4k.store.InMemoryFeatureStore
+import com.yonatankarp.ff4k.test.contract.strategy.FlippingStrategyContractTest
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+
+class ClientFilterStrategyTest : FlippingStrategyContractTest() {
+
+    init {
+        test("context key is required") {
+            // Given
+            val strategy = createStrategyForPassingCase()
+            val store = InMemoryFeatureStore()
+            val emptyContext = FlippingExecutionContext()
+
+            // When / Then
+            shouldThrow<IllegalStateException> {
+                strategy.evaluate("test", store, emptyContext)
+            }
+        }
+
+        test("vararg constructor populates granted clients") {
+            ClientFilterStrategy("client-a", "client-b").grantedClients shouldBe setOf("client-a", "client-b")
+        }
+    }
+
+    override fun createStrategyForPassingCase(): FlippingStrategy = ClientFilterStrategy(setOf(ALLOWED_CLIENT_HOSTNAME))
+
+    override fun createStrategyForFailingCase(): FlippingStrategy = ClientFilterStrategy(setOf(ALLOWED_CLIENT_HOSTNAME))
+
+    override fun contextThatShouldPass(): FlippingExecutionContext = FlippingExecutionContext(
+        values = mapOf(ContextKeys.CLIENT_HOSTNAME to ALLOWED_CLIENT_HOSTNAME),
+    )
+
+    override fun contextThatShouldFail(): FlippingExecutionContext = FlippingExecutionContext(
+        values = mapOf(ContextKeys.CLIENT_HOSTNAME to REJECTED_CLIENT_HOSTNAME),
+    )
+
+    override fun expectedJsonForSampleParams(): String = // language=json
+        """{"type":"clientFilter","grantedClients":["$ALLOWED_CLIENT_HOSTNAME"]}"""
+
+    companion object {
+        private const val ALLOWED_CLIENT_HOSTNAME = "http://localhost:8080"
+        private const val REJECTED_CLIENT_HOSTNAME = "http://www.google.com"
+    }
+}

--- a/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/strategy/RegionFilterStrategyTest.kt
+++ b/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/strategy/RegionFilterStrategyTest.kt
@@ -1,0 +1,49 @@
+package com.yonatankarp.ff4k.strategy
+
+import com.yonatankarp.ff4k.core.ContextKeys
+import com.yonatankarp.ff4k.core.FlippingExecutionContext
+import com.yonatankarp.ff4k.core.FlippingStrategy
+import com.yonatankarp.ff4k.store.InMemoryFeatureStore
+import com.yonatankarp.ff4k.test.contract.strategy.FlippingStrategyContractTest
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+
+class RegionFilterStrategyTest : FlippingStrategyContractTest() {
+    init {
+        test("context key is required") {
+            // Given
+            val strategy = createStrategyForPassingCase()
+            val store = InMemoryFeatureStore()
+            val emptyContext = FlippingExecutionContext()
+
+            // When / Then
+            shouldThrow<IllegalStateException> {
+                strategy.evaluate("test", store, emptyContext)
+            }
+        }
+
+        test("vararg constructor populates granted regions") {
+            RegionFilterStrategy("eu-central-1", "us-west-2").grantedRegions shouldBe setOf("eu-central-1", "us-west-2")
+        }
+    }
+
+    override fun createStrategyForPassingCase(): FlippingStrategy = RegionFilterStrategy(setOf(ALLOWED_REGIONS))
+
+    override fun createStrategyForFailingCase(): FlippingStrategy = RegionFilterStrategy(setOf(ALLOWED_REGIONS))
+
+    override fun contextThatShouldPass(): FlippingExecutionContext = FlippingExecutionContext(
+        values = mapOf(ContextKeys.REGION to ALLOWED_REGIONS),
+    )
+
+    override fun contextThatShouldFail(): FlippingExecutionContext = FlippingExecutionContext(
+        values = mapOf(ContextKeys.REGION to REJECTED_REGIONS),
+    )
+
+    override fun expectedJsonForSampleParams(): String = // language=json
+        """{"type":"region","grantedRegions":["$ALLOWED_REGIONS"]}"""
+
+    companion object {
+        private const val ALLOWED_REGIONS = "eu-central-1"
+        private const val REJECTED_REGIONS = "us-west-3"
+    }
+}

--- a/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/strategy/ServerFilterStrategyTest.kt
+++ b/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/strategy/ServerFilterStrategyTest.kt
@@ -1,0 +1,50 @@
+package com.yonatankarp.ff4k.strategy
+
+import com.yonatankarp.ff4k.core.ContextKeys
+import com.yonatankarp.ff4k.core.FlippingExecutionContext
+import com.yonatankarp.ff4k.core.FlippingStrategy
+import com.yonatankarp.ff4k.store.InMemoryFeatureStore
+import com.yonatankarp.ff4k.test.contract.strategy.FlippingStrategyContractTest
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+
+class ServerFilterStrategyTest : FlippingStrategyContractTest() {
+
+    init {
+        test("context key is required") {
+            // Given
+            val strategy = createStrategyForPassingCase()
+            val store = InMemoryFeatureStore()
+            val emptyContext = FlippingExecutionContext()
+
+            // When / Then
+            shouldThrow<IllegalStateException> {
+                strategy.evaluate("test", store, emptyContext)
+            }
+        }
+
+        test("vararg constructor populates target servers") {
+            ServerFilterStrategy("server-a", "server-b").targetServers shouldBe setOf("server-a", "server-b")
+        }
+    }
+
+    override fun createStrategyForPassingCase(): FlippingStrategy = ServerFilterStrategy(setOf(ALLOWED_SERVER_HOSTNAME))
+
+    override fun createStrategyForFailingCase(): FlippingStrategy = ServerFilterStrategy(setOf(ALLOWED_SERVER_HOSTNAME))
+
+    override fun contextThatShouldPass(): FlippingExecutionContext = FlippingExecutionContext(
+        values = mapOf(ContextKeys.SERVER_HOSTNAME to ALLOWED_SERVER_HOSTNAME),
+    )
+
+    override fun contextThatShouldFail(): FlippingExecutionContext = FlippingExecutionContext(
+        values = mapOf(ContextKeys.SERVER_HOSTNAME to REJECTED_SERVER_HOSTNAME),
+    )
+
+    override fun expectedJsonForSampleParams(): String = // language=json
+        """{"type":"serverFilter","targetServers":["$ALLOWED_SERVER_HOSTNAME"]}"""
+
+    companion object {
+        private const val ALLOWED_SERVER_HOSTNAME = "http://localhost:8080"
+        private const val REJECTED_SERVER_HOSTNAME = "http://www.google.com"
+    }
+}


### PR DESCRIPTION
Add ClientFilterStrategy, ServerFilterStrategy, and RegionFilterStrategy for filtering features by client hostname, server hostname, and geographic region respectively. Include DSL extensions, KDoc documentation, and tests.

Extract ListBuilder and WeekdayBuilder into dedicated files with full test coverage, simplifying StrategyDsl and its tests to focus on wiring.

Closes #24

## Summary

Add `ClientFilterStrategy`, `ServerFilterStrategy`, and `RegionFilterStrategy` for filtering features by client hostname, server hostname, and geographic region. Extract DSL builders into dedicated files with full test coverage.

## Motivation

Enables infrastructure-aware feature toggling based on client origin, server instance, and geographic region - useful for canary deployments, region-specific rollouts, and client-scoped features.

Closes #24 

## Changes

<!-- What does this PR do? List the main changes -->

  - Add ClientFilterStrategy, ServerFilterStrategy, and RegionFilterStrategy with KDoc and serialization support                                                                                                                         
  - Add CLIENT_HOSTNAME and SERVER_HOSTNAME to ContextKeys                                                                                                                                                                               
  - Add DSL extensions (clientFilterStrategy, serverFilterStrategy, regionStrategy)                                                                                                                                                      
  - Extract ListBuilder and WeekdayBuilder from StrategyDsl.kt into their own files                                                                                                                                                      
  - Simplify StrategyDslTest to wiring-only assertions (builder logic now tested separately)                                                                                                                                             
  - Add strategy documentation to docs/usage/strategies.md   

## Testing

<!-- How did you test these changes? -->

- [x] Unit tests added/updated
- [x] Tested on JVM
- [x] Tested on Android
- [x] Tested on iOS

## Checklist

- [x] My code follows the project's code style (`./gradlew spotlessCheck` passes)
- [x] I have added tests that prove my fix/feature works
- [x] All tests pass (`./gradlew check`)
- [x] I have updated documentation if needed
- [ ] I marked all checkboxes without reading


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added three new filtering strategies for feature flags: client hostname filtering, server hostname filtering, and region-based filtering. These enable precise feature control based on deployment environment.
  * Enhanced DSL syntax for simplified strategy configuration.

* **Documentation**
  * Added comprehensive usage examples and guides for the new filtering strategies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->