### PR TITLE
chore: remove `@author` attribution to codebase

### DIFF
--- a/build-logic/src/main/kotlin/ff4k.multiplatform.gradle.kts
+++ b/build-logic/src/main/kotlin/ff4k.multiplatform.gradle.kts
@@ -59,14 +59,18 @@ spotless {
         targetExclude("**/build/**/*.kt")
         ktlint().editorConfigOverride(
             mapOf(
-                "ktlint_standard_filename" to "disabled"
+                "ktlint_standard_filename" to "disabled",
+                "ktlint_standard_no-unused-imports" to "enabled"
             )
         )
     }
-
     kotlinGradle {
         target("**/*.gradle.kts")
         targetExclude("**/build/**/*.gradle.kts")
-        ktlint()
+        ktlint().editorConfigOverride(
+            mapOf(
+                "ktlint_standard_no-unused-imports" to "enabled"
+            )
+        )
     }
 }

--- a/ff4k-contract-test/src/commonMain/kotlin/com/yonatankarp/ff4k/test/contract/store/FeatureStoreContractTest.kt
+++ b/ff4k-contract-test/src/commonMain/kotlin/com/yonatankarp/ff4k/test/contract/store/FeatureStoreContractTest.kt
@@ -26,8 +26,6 @@ import io.kotest.core.spec.style.FunSpec
  *     override suspend fun createStore(): FeatureStore = InMemoryFeatureStore()
  * }
  * ```
- *
- * @author Yonatan Karp-Rudin (@yonatankarp)
  */
 abstract class FeatureStoreContractTest(body: FunSpec.() -> Unit = {}) : FunSpec(body) {
     abstract suspend fun createStore(): FeatureStore

--- a/ff4k-contract-test/src/commonMain/kotlin/com/yonatankarp/ff4k/test/contract/store/PropertyStoreContractTest.kt
+++ b/ff4k-contract-test/src/commonMain/kotlin/com/yonatankarp/ff4k/test/contract/store/PropertyStoreContractTest.kt
@@ -22,8 +22,6 @@ import io.kotest.core.spec.style.FunSpec
  *     override suspend fun createStore(): PropertyStore = InMemoryPropertyStore()
  * }
  * ```
- *
- * @author Yonatan Karp-Rudin (@yonatankarp)
  */
 abstract class PropertyStoreContractTest(body: FunSpec.() -> Unit = {}) : FunSpec(body) {
     abstract suspend fun createStore(): PropertyStore

--- a/ff4k-contract-test/src/commonMain/kotlin/com/yonatankarp/ff4k/test/contract/store/property/PropertyStoreConcurrencyTests.kt
+++ b/ff4k-contract-test/src/commonMain/kotlin/com/yonatankarp/ff4k/test/contract/store/property/PropertyStoreConcurrencyTests.kt
@@ -5,7 +5,6 @@ package com.yonatankarp.ff4k.test.contract.store.property
 import com.yonatankarp.ff4k.core.PropertyStore
 import com.yonatankarp.ff4k.core.count
 import com.yonatankarp.ff4k.core.createOrUpdateProperty
-import com.yonatankarp.ff4k.exception.PropertyNotFoundException
 import com.yonatankarp.ff4k.property.PropertyInt
 import com.yonatankarp.ff4k.test.contract.store.property.PropertyStoreFixture.PROPERTY_NAME
 import io.kotest.core.spec.style.FunSpec

--- a/ff4k-contract-test/src/commonMain/kotlin/com/yonatankarp/ff4k/test/contract/store/property/PropertyStoreFixture.kt
+++ b/ff4k-contract-test/src/commonMain/kotlin/com/yonatankarp/ff4k/test/contract/store/property/PropertyStoreFixture.kt
@@ -1,5 +1,4 @@
 package com.yonatankarp.ff4k.test.contract.store.property
-
 internal object PropertyStoreFixture {
     const val PROPERTY_NAME = "testProperty"
     const val DEFAULT_VALUE = 42

--- a/ff4k-contract-test/src/commonMain/kotlin/com/yonatankarp/ff4k/test/contract/strategy/FlippingStrategyContractTest.kt
+++ b/ff4k-contract-test/src/commonMain/kotlin/com/yonatankarp/ff4k/test/contract/strategy/FlippingStrategyContractTest.kt
@@ -16,8 +16,6 @@ import kotlinx.serialization.encodeToString
  * Contract test for FlippingStrategy implementations.
  *
  * Extend this class to test custom flipping strategy implementations.
- *
- * @author Yonatan Karp-Rudin
  */
 abstract class FlippingStrategyContractTest(body: FunSpec.() -> Unit = {}) : FunSpec(body) {
 

--- a/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/FF4k.kt
+++ b/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/FF4k.kt
@@ -124,7 +124,6 @@ import kotlinx.coroutines.sync.Mutex
  * @property autoCreate When `true`, automatically creates missing features as disabled on first access.
  *                      When `false`, throws [FeatureNotFoundException] for missing features.
  *
- * @author Yonatan Karp-Rudin (@yonatankarp)
  * @see FeatureStore
  * @see PropertyStore
  * @see Feature

--- a/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/core/Feature.kt
+++ b/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/core/Feature.kt
@@ -45,8 +45,6 @@ import kotlinx.serialization.Serializable
  * ```
  *
  * @throws IllegalArgumentException if [uid] is blank or [group] is blank (when non-null)
- *
- * @author Yonatan Karp-Rudin (@yonatankarp)
  */
 @Serializable
 data class Feature(

--- a/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/core/FeatureStore.kt
+++ b/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/core/FeatureStore.kt
@@ -33,8 +33,6 @@ import com.yonatankarp.ff4k.exception.FeatureNotFoundException
  * // Delete feature
  * store -= "dark-mode"
  * ```
- *
- * @author Yonatan Karp-Rudin (@yonatankarp)
  */
 interface FeatureStore {
 

--- a/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/core/FlippingExecutionContext.kt
+++ b/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/core/FlippingExecutionContext.kt
@@ -27,8 +27,6 @@ import kotlin.coroutines.CoroutineContext
  * // Immutable modification (creates new instance)
  * val newContext = context.withParameter(ContextKeys.REGION, "EU")
  * ```
- *
- * @author Yonatan Karp-Rudin (@yonatankarp)
  */
 data class FlippingExecutionContext(
     @PublishedApi internal val values: Map<String, Any> = emptyMap(),

--- a/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/core/FlippingStrategy.kt
+++ b/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/core/FlippingStrategy.kt
@@ -39,8 +39,6 @@ package com.yonatankarp.ff4k.core
  *     }
  * }
  * ```
- *
- * @author Yonatan Karp-Rudin (@yonatankarp)
  */
 fun interface FlippingStrategy {
     /**

--- a/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/core/PropertyStore.kt
+++ b/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/core/PropertyStore.kt
@@ -7,8 +7,6 @@ import com.yonatankarp.ff4k.property.Property
  *
  * PropertyStore provides a collection-like interface for storing and retrieving
  * properties with support for operator overloading and suspending operations.
- *
- * @author Yonatan Karp-Rudin (@yonatankarp)
  */
 interface PropertyStore {
 

--- a/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/dsl/core/DslCollectors.kt
+++ b/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/dsl/core/DslCollectors.kt
@@ -14,8 +14,6 @@ package com.yonatankarp.ff4k.dsl.core
  * when used inside nested DSL blocks.
  *
  * @param T the type of elements collected by this builder
- *
- * @author Yonatan Karp-Rudin (@yonatankarp)
  */
 @FF4kDsl
 abstract class SetCollector<T> {
@@ -85,8 +83,6 @@ abstract class SetCollector<T> {
  * This class is marked with [FF4kDsl] to enforce proper DSL scoping rules.
  *
  * @param T the type of elements collected by this builder
- *
- * @author Yonatan Karp-Rudin (@yonatankarp)
  */
 @FF4kDsl
 abstract class ListCollector<T> {

--- a/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/dsl/core/FF4kBuilder.kt
+++ b/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/dsl/core/FF4kBuilder.kt
@@ -59,8 +59,6 @@ import com.yonatankarp.ff4k.store.InMemoryPropertyStore
  *
  * This class is annotated with [FF4kDsl] to prevent accidental receiver leakage
  * when nesting DSL blocks (e.g. feature builders inside the root DSL).
- *
- * @author Yonatan Karp-Rudin (@yonatankarp)
  */
 @FF4kDsl
 class FF4kBuilder internal constructor(
@@ -203,8 +201,6 @@ class FF4kBuilder internal constructor(
  * @param block DSL block used to configure the FF4k instance
  *
  * @return a fully configured [FF4k] instance
- *
- * @author Yonatan Karp-Rudin (@yonatankarp)
  */
 suspend fun ff4k(
     featureStore: FeatureStore = InMemoryFeatureStore(),

--- a/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/dsl/core/FF4kDsl.kt
+++ b/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/dsl/core/FF4kDsl.kt
@@ -10,7 +10,6 @@ package com.yonatankarp.ff4k.dsl.core
  * safe and readable DSL usage.
  *
  * @see DslMarker
- * @author Yonatan Karp-Rudin (@yonatankarp)
  */
 @DslMarker
 @Target(AnnotationTarget.CLASS, AnnotationTarget.TYPE)

--- a/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/dsl/feature/FeatureBuilder.kt
+++ b/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/dsl/feature/FeatureBuilder.kt
@@ -35,8 +35,6 @@ import com.yonatankarp.ff4k.property.Property
  * @property description Optional human-readable description of the feature
  * @property group Optional logical group name for categorization
  * @property flippingStrategy Optional strategy controlling dynamic enablement
- *
- * @author Yonatan Karp-Rudin (@yonatankarp)
  */
 @FF4kDsl
 class FeatureBuilder internal constructor(
@@ -145,8 +143,6 @@ class FeatureBuilder internal constructor(
  *     +"BETA_USER"
  * }
  * ```
- *
- * @author Yonatan Karp-Rudin (@yonatankarp)
  */
 @FF4kDsl
 class PermissionsBuilder : SetCollector<String>()

--- a/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/dsl/feature/FeatureDsl.kt
+++ b/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/dsl/feature/FeatureDsl.kt
@@ -28,8 +28,6 @@ import com.yonatankarp.ff4k.dsl.internal.feature as featureDsl
  * @param block DSL block to configure the [FeatureBuilder]
  * @return A fully built [Feature] instance
  * @throws IllegalArgumentException if any property inside the block is invalid
- *
- * @author Yonatan Karp-Rudin (@yonatankarp)
  */
 fun feature(uid: String, block: FeatureBuilder.() -> Unit): Feature = featureDsl(uid, block)
 
@@ -54,6 +52,5 @@ fun feature(uid: String, block: FeatureBuilder.() -> Unit): Feature = featureDsl
  *
  * @param block DSL block to configure [FeaturesBuilder] with multiple features
  * @return List of fully built [Feature] instances
- * @author Yonatan Karp-Rudin (@yonatankarp)
  */
 fun features(block: FeaturesBuilder.() -> Unit): List<Feature> = FeaturesBuilder().apply(block).build()

--- a/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/dsl/feature/FeaturesBuilder.kt
+++ b/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/dsl/feature/FeaturesBuilder.kt
@@ -28,8 +28,6 @@ import com.yonatankarp.ff4k.dsl.internal.feature as featureDsl
  *     ))
  * }.build()
  * ```
- *
- * @author Yonatan Karp-Rudin (@yonatankarp)
  */
 @FF4kDsl
 class FeaturesBuilder : ListCollector<Feature>() {

--- a/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/dsl/internal/BuilderFactories.kt
+++ b/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/dsl/internal/BuilderFactories.kt
@@ -14,7 +14,6 @@ import com.yonatankarp.ff4k.property.Property
  * @param uid Unique identifier for the feature
  * @param block DSL block to configure the [FeatureBuilder]
  * @return A fully built [Feature] instance
- * @author Yonatan Karp-Rudin (@yonatankarp)
  */
 internal fun feature(
     uid: String,
@@ -30,7 +29,6 @@ internal fun feature(
  * @param name Name of the property
  * @param block DSL block to configure the [PropertyBuilder]
  * @return A fully built [Property] instance of type [T]
- * @author Yonatan Karp-Rudin (@yonatankarp)
  */
 internal fun <T> property(
     name: String,

--- a/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/dsl/property/FF4kPropertyDsl.kt
+++ b/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/dsl/property/FF4kPropertyDsl.kt
@@ -9,8 +9,6 @@ package com.yonatankarp.ff4k.dsl.property
  * It ensures that configuration blocks such as `fixedValues {}` can only be
  * invoked in their intended context (for example, inside a property definition),
  * providing better compile-time safety and clearer DSL usage.
- *
- * @author Yonatan Karp-Rudin (@yonatankarp)
  */
 @DslMarker
 @Target(AnnotationTarget.CLASS, AnnotationTarget.TYPE)

--- a/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/dsl/property/FixedValuesBuilder.kt
+++ b/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/dsl/property/FixedValuesBuilder.kt
@@ -37,8 +37,6 @@ import com.yonatankarp.ff4k.dsl.core.SetCollector
  * ```
  *
  * @param T Type of the values in the set
- *
- * @author Yonatan Karp-Rudin (@yonatankarp)
  */
 @FF4kPropertyDsl
 class FixedValuesBuilder<T> : SetCollector<T>()

--- a/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/dsl/property/PropertiesBuilder.kt
+++ b/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/dsl/property/PropertiesBuilder.kt
@@ -24,8 +24,6 @@ import com.yonatankarp.ff4k.dsl.internal.property as propertyDsl
  *     property(PropertyString("api-key", "secret"))
  * }.build()
  * ```
- *
- * @author Yonatan Karp-Rudin (@yonatankarp)
  */
 @FF4kDsl
 class PropertiesBuilder : ListCollector<Property<*>>() {

--- a/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/dsl/property/PropertyBuilder.kt
+++ b/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/dsl/property/PropertyBuilder.kt
@@ -53,8 +53,6 @@ import kotlinx.datetime.LocalDateTime
  * - [readOnly] marks the property as immutable after creation.
  *
  * @param T Type of the property value
- *
- * @author Yonatan Karp-Rudin (@yonatankarp)
  */
 @FF4kDsl
 class PropertyBuilder<T> internal constructor(

--- a/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/dsl/property/PropertyDsl.kt
+++ b/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/dsl/property/PropertyDsl.kt
@@ -30,8 +30,6 @@ import com.yonatankarp.ff4k.dsl.internal.property as propertyDsl
  * @return The fully-built [Property] of type [T]
  * @throws IllegalStateException if [PropertyBuilder.value] is not set
  * @throws IllegalArgumentException if the value type is unsupported
- *
- * @author Yonatan Karp-Rudin (@yonatankarp)
  */
 fun <T> property(name: String, block: PropertyBuilder<T>.() -> Unit): Property<T> = propertyDsl(name, block)
 
@@ -57,7 +55,5 @@ fun <T> property(name: String, block: PropertyBuilder<T>.() -> Unit): Property<T
  *
  * @param block DSL block used to define multiple properties
  * @return A list of fully-built [Property] instances
- *
- * @author Yonatan Karp-Rudin (@yonatankarp)
  */
 fun properties(block: PropertiesBuilder.() -> Unit): List<Property<*>> = PropertiesBuilder().apply(block).build()

--- a/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/exception/FF4kException.kt
+++ b/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/exception/FF4kException.kt
@@ -14,7 +14,5 @@ package com.yonatankarp.ff4k.exception
  * @param cause The underlying cause of this exception, or null if none
  *
  * @see FeatureStoreException Base exception for feature store operations
- *
- * @author Yonatan Karp-Rudin (@yonatankarp)
  */
 sealed class FF4kException(message: String, cause: Throwable? = null) : Exception(message, cause)

--- a/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/exception/FeatureStoreException.kt
+++ b/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/exception/FeatureStoreException.kt
@@ -16,8 +16,6 @@ package com.yonatankarp.ff4k.exception
  * @param cause The underlying cause of this exception, or null if none
  *
  * @see com.yonatankarp.ff4k.core.FeatureStore
- *
- * @author Yonatan Karp-Rudin (@yonatankarp)
  */
 sealed class FeatureStoreException(message: String, cause: Throwable? = null) : FF4kException(message, cause)
 

--- a/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/exception/PropertyStoreException.kt
+++ b/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/exception/PropertyStoreException.kt
@@ -17,8 +17,6 @@ package com.yonatankarp.ff4k.exception
  *
  * @see com.yonatankarp.ff4k.core.Feature.getProperty
  * @see com.yonatankarp.ff4k.property.Property
- *
- * @author Yonatan Karp-Rudin (@yonatankarp)
  */
 sealed class PropertyStoreException(message: String, cause: Throwable? = null) : FF4kException(message, cause)
 

--- a/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/property/Property.kt
+++ b/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/property/Property.kt
@@ -19,8 +19,6 @@ package com.yonatankarp.ff4k.property
  * - **Serialization**: Built-in support for JSON serialization
  *
  * @param T The type of the property value.
- *
- * @author Yonatan Karp-Rudin (@yonatankarp)
  */
 interface Property<T> {
     /**

--- a/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/property/PropertyBigDecimal.kt
+++ b/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/property/PropertyBigDecimal.kt
@@ -13,8 +13,6 @@ import kotlinx.serialization.Serializable
  * @property description Optional description
  * @property fixedValues Set of allowed [com.ionspin.kotlin.bignum.decimal.BigDecimal] values (empty if no restrictions)
  * @property readOnly Whether the property is read-only
- *
- * @author Yonatan Karp-Rudin
  */
 @Serializable
 @SerialName("bigDecimal")

--- a/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/property/PropertyBigInteger.kt
+++ b/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/property/PropertyBigInteger.kt
@@ -13,8 +13,6 @@ import kotlinx.serialization.Serializable
  * @property description Optional description
  * @property fixedValues Set of allowed [com.ionspin.kotlin.bignum.integer.BigInteger] values (empty if no restrictions)
  * @property readOnly Whether the property is read-only
- *
- * @author Yonatan Karp-Rudin
  */
 @Serializable
 @SerialName("bigInteger")

--- a/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/property/PropertyBoolean.kt
+++ b/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/property/PropertyBoolean.kt
@@ -11,8 +11,6 @@ import kotlinx.serialization.Serializable
  * @property description Optional description
  * @property fixedValues Set of allowed boolean values (empty if no restrictions)
  * @property readOnly Whether the property is read-only
- *
- * @author Yonatan Karp-Rudin
  */
 @Serializable
 @SerialName("boolean")

--- a/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/property/PropertyByte.kt
+++ b/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/property/PropertyByte.kt
@@ -11,8 +11,6 @@ import kotlinx.serialization.Serializable
  * @property description Optional description
  * @property fixedValues Set of allowed byte values (empty if no restrictions)
  * @property readOnly Whether the property is read-only
- *
- * @author Yonatan Karp-Rudin
  */
 @Serializable
 @SerialName("byte")

--- a/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/property/PropertyDouble.kt
+++ b/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/property/PropertyDouble.kt
@@ -11,8 +11,6 @@ import kotlinx.serialization.Serializable
  * @property description Optional description
  * @property fixedValues Set of allowed double values (empty if no restrictions)
  * @property readOnly Whether the property is read-only
- *
- * @author Yonatan Karp-Rudin
  */
 @Serializable
 @SerialName("double")

--- a/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/property/PropertyFloat.kt
+++ b/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/property/PropertyFloat.kt
@@ -11,8 +11,6 @@ import kotlinx.serialization.Serializable
  * @property description Optional description
  * @property fixedValues Set of allowed float values (empty if no restrictions)
  * @property readOnly Whether the property is read-only
- *
- * @author Yonatan Karp-Rudin
  */
 @Serializable
 @SerialName("float")

--- a/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/property/PropertyInstant.kt
+++ b/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/property/PropertyInstant.kt
@@ -12,8 +12,6 @@ import kotlinx.serialization.Serializable
  * @property description Optional description
  * @property fixedValues Set of allowed instant values (empty if no restrictions)
  * @property readOnly Whether the property is read-only
- *
- * @author Yonatan Karp-Rudin
  */
 @Serializable
 @SerialName("instant")

--- a/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/property/PropertyInt.kt
+++ b/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/property/PropertyInt.kt
@@ -11,8 +11,6 @@ import kotlinx.serialization.Serializable
  * @property description Optional description
  * @property fixedValues Set of allowed integer values (empty if no restrictions)
  * @property readOnly Whether the property is read-only
- *
- * @author Yonatan Karp-Rudin
  */
 @Serializable
 @SerialName("int")

--- a/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/property/PropertyLocalDate.kt
+++ b/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/property/PropertyLocalDate.kt
@@ -12,8 +12,6 @@ import kotlinx.serialization.Serializable
  * @property description Optional description
  * @property fixedValues Set of allowed local date values (empty if no restrictions)
  * @property readOnly Whether the property is read-only
- *
- * @author Yonatan Karp-Rudin
  */
 @Serializable
 @SerialName("localDate")

--- a/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/property/PropertyLocalDateTime.kt
+++ b/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/property/PropertyLocalDateTime.kt
@@ -12,8 +12,6 @@ import kotlinx.serialization.Serializable
  * @property description Optional description
  * @property fixedValues Set of allowed local date time values (empty if no restrictions)
  * @property readOnly Whether the property is read-only
- *
- * @author Yonatan Karp-Rudin
  */
 @Serializable
 @SerialName("localDateTime")

--- a/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/property/PropertyLogLevel.kt
+++ b/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/property/PropertyLogLevel.kt
@@ -11,8 +11,6 @@ import kotlinx.serialization.Serializable
  * @property description Optional description
  * @property fixedValues Set of allowed log level values (empty if no restrictions)
  * @property readOnly Whether the property is read-only
- *
- * @author Yonatan Karp-Rudin
  */
 @Serializable
 @SerialName("logLevel")

--- a/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/property/PropertyLong.kt
+++ b/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/property/PropertyLong.kt
@@ -11,8 +11,6 @@ import kotlinx.serialization.Serializable
  * @property description Optional description
  * @property fixedValues Set of allowed long values (empty if no restrictions)
  * @property readOnly Whether the property is read-only
- *
- * @author Yonatan Karp-Rudin
  */
 @Serializable
 @SerialName("long")

--- a/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/property/PropertyShort.kt
+++ b/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/property/PropertyShort.kt
@@ -11,8 +11,6 @@ import kotlinx.serialization.Serializable
  * @property description Optional description
  * @property fixedValues Set of allowed short values (empty if no restrictions)
  * @property readOnly Whether the property is read-only
- *
- * @author Yonatan Karp-Rudin
  */
 @Serializable
 @SerialName("short")

--- a/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/property/PropertyString.kt
+++ b/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/property/PropertyString.kt
@@ -11,8 +11,6 @@ import kotlinx.serialization.Serializable
  * @property description Optional description
  * @property fixedValues Set of allowed string values (empty if no restrictions)
  * @property readOnly Whether the property is read-only
- *
- * @author Yonatan Karp-Rudin
  */
 @Serializable
 @SerialName("string")

--- a/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/property/multi/AbstractPropertyList.kt
+++ b/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/property/multi/AbstractPropertyList.kt
@@ -10,8 +10,6 @@ package com.yonatankarp.ff4k.property.multi
  * @param readOnly If true, the property cannot be modified.
  *
  * @param T current type
- *
- * @author Yonatan Karp-Rudin (@yonatankarp)
  */
 abstract class AbstractPropertyList<T>(
     name: String,

--- a/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/property/multi/AbstractPropertyMap.kt
+++ b/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/property/multi/AbstractPropertyMap.kt
@@ -8,8 +8,6 @@ private typealias Values<V> = MutableCollection<V>
 /**
  * SuperClass for property as maps.
  *
- * @author Yonatan Karp-Rudin (@yonatankarp)
- *
  * @param <T> current inner type
  * @param <M> current map type
  */

--- a/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/property/multi/AbstractPropertyMultiValued.kt
+++ b/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/property/multi/AbstractPropertyMultiValued.kt
@@ -7,8 +7,6 @@ import com.yonatankarp.ff4k.property.Property
  *
  * @param <T> current inner type
  * @param <C> current collection type
- *
- * @author Yonatan Karp-Rudin (@yonatankarp)
  */
 abstract class AbstractPropertyMultiValued<T, C : MutableCollection<T>>(
     override val name: String,

--- a/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/property/multi/AbstractPropertySet.kt
+++ b/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/property/multi/AbstractPropertySet.kt
@@ -4,8 +4,6 @@ package com.yonatankarp.ff4k.property.multi
  * SuperClass for property as lists.
  *
  * @param <T> current type
- *
- * @author Yonatan Karp-Rudin (@yonatankarp)
  */
 @Suppress("UNCHECKED_CAST")
 abstract class AbstractPropertySet<T, S : MutableSet<T>>(

--- a/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/store/AbstractFeatureStore.kt
+++ b/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/store/AbstractFeatureStore.kt
@@ -15,8 +15,6 @@ import com.yonatankarp.ff4k.exception.GroupNotFoundException
  *
  * This class implements many of the default behaviors for a feature store,
  * allowing specific implementations to focus on the storage mechanism itself.
- *
- * @author Yonatan Karp-Rudin (@yonatankarp)
  */
 abstract class AbstractFeatureStore : FeatureStore {
 

--- a/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/store/InMemoryFeatureStore.kt
+++ b/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/store/InMemoryFeatureStore.kt
@@ -20,7 +20,6 @@ import kotlinx.coroutines.sync.Mutex
  * - Prototyping feature flag systems
  *
  * @param initialFeatures Optional map of features to initialize the store with
- * @author Yonatan Karp-Rudin (@yonatankarp)
  */
 class InMemoryFeatureStore(
     initialFeatures: Map<String, Feature> = emptyMap(),

--- a/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/store/InMemoryPropertyStore.kt
+++ b/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/store/InMemoryPropertyStore.kt
@@ -26,8 +26,6 @@ import kotlinx.coroutines.sync.Mutex
  *
  * Despite being thread-safe within a single process, this implementation does not
  * provide any cross-process or distributed consistency guarantees.
- *
- * @author Yonatan Karp
  */
 class InMemoryPropertyStore(
     initialProperties: Map<String, Property<*>> = emptyMap(),

--- a/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/FF4kExtensionsTest.kt
+++ b/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/FF4kExtensionsTest.kt
@@ -12,8 +12,6 @@ import io.kotest.matchers.shouldBe
 
 /**
  * Tests for FF4k conditional execution and batch check extension functions.
- *
- * @author Yonatan Karp-Rudin
  */
 internal class FF4kExtensionsTest :
     FunSpec({
@@ -22,7 +20,7 @@ internal class FF4kExtensionsTest :
             withData(
                 nameFn = { it.description },
                 ifEnabledData,
-            ) { (description, featuresBlock, context, expected) ->
+            ) { (_, featuresBlock, context, expected) ->
                 // Given
                 val ff4k = ff4k {
                     features(featuresBlock)
@@ -44,7 +42,7 @@ internal class FF4kExtensionsTest :
             withData(
                 nameFn = { it.description },
                 ifEnabledOrElseData,
-            ) { (description, featuresBlock, context, expected) ->
+            ) { (_, featuresBlock, context, expected) ->
                 // Given
                 val ff4k = ff4k {
                     features(featuresBlock)
@@ -75,7 +73,7 @@ internal class FF4kExtensionsTest :
             withData(
                 nameFn = { it.description },
                 whenEnabledData,
-            ) { (description, featuresBlock, context, expected) ->
+            ) { (_, featuresBlock, context, expected) ->
                 // Given
                 val ff4k = ff4k {
                     features(featuresBlock)

--- a/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/FF4kStatsTest.kt
+++ b/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/FF4kStatsTest.kt
@@ -11,8 +11,6 @@ import io.kotest.matchers.string.shouldContain
 
 /**
  * Tests for FF4k filtering, statistics, and reporting extension functions.
- *
- * @author Yonatan Karp-Rudin
  */
 internal class FF4kStatsTest :
     FunSpec({
@@ -394,6 +392,7 @@ internal class FF4kStatsTest :
         )
     }
 }
+
 private data class ReportTestData(
     val description: String,
     val featuresBlock: FeaturesBuilder.() -> Unit,

--- a/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/FF4kTest.kt
+++ b/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/FF4kTest.kt
@@ -19,8 +19,6 @@ import io.kotest.matchers.types.shouldBeSameInstanceAs
 
 /**
  * Tests for the FF4k main class.
- *
- * @author Yonatan Karp-Rudin
  */
 internal class FF4kTest :
     FunSpec({

--- a/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/config/FileIOTest.kt
+++ b/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/config/FileIOTest.kt
@@ -259,5 +259,7 @@ internal class FileIOTest :
     })
 
 expect fun createTempFilePath(): String
+
 expect fun deleteTempFile(path: String)
+
 expect fun getHomeDirectory(): String

--- a/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/core/FeatureTest.kt
+++ b/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/core/FeatureTest.kt
@@ -20,8 +20,6 @@ import kotlinx.serialization.json.Json
 
 /**
  * Tests for Feature.
- *
- * @author Yonatan Karp-Rudin
  */
 internal class FeatureTest :
     FunSpec({

--- a/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/core/FeaturesTest.kt
+++ b/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/core/FeaturesTest.kt
@@ -19,8 +19,6 @@ import io.kotest.matchers.shouldBe
 
 /**
  * Tests for Feature extension functions defined in Features.kt.
- *
- * @author Yonatan Karp-Rudin
  */
 internal class FeaturesTest :
     FunSpec({

--- a/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/core/FlippingExecutionContextTest.kt
+++ b/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/core/FlippingExecutionContextTest.kt
@@ -8,8 +8,6 @@ import io.kotest.matchers.shouldBe
 
 /**
  * Tests for FlippingExecutionContext.
- *
- * @author Yonatan Karp-Rudin
  */
 internal class FlippingExecutionContextTest :
     FunSpec({

--- a/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/core/FlippingExecutionContextsTest.kt
+++ b/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/core/FlippingExecutionContextsTest.kt
@@ -9,8 +9,6 @@ import io.kotest.matchers.shouldBe
 
 /**
  * Tests for FlippingExecutionContext extension functions and coroutine context propagation.
- *
- * @author Yonatan Karp-Rudin
  */
 internal class FlippingExecutionContextsTest :
     FunSpec({

--- a/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/dsl/core/DslCollectorsTest.kt
+++ b/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/dsl/core/DslCollectorsTest.kt
@@ -1,15 +1,12 @@
 package com.yonatankarp.ff4k.dsl.core
 
 import io.kotest.core.spec.style.FunSpec
-import io.kotest.matchers.booleans.shouldBeTrue
 import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.shouldBe
 
 /**
  * Tests for SetCollector and ListCollector DSL base classes.
- *
- * @author Yonatan Karp-Rudin
  */
 internal class DslCollectorsTest :
     FunSpec({

--- a/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/dsl/core/FF4kBuilderTest.kt
+++ b/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/dsl/core/FF4kBuilderTest.kt
@@ -1,7 +1,6 @@
 package com.yonatankarp.ff4k.dsl.core
 
 import com.yonatankarp.ff4k.core.Feature
-import com.yonatankarp.ff4k.core.FlippingStrategy
 import com.yonatankarp.ff4k.property.PropertyInt
 import com.yonatankarp.ff4k.property.PropertyString
 import com.yonatankarp.ff4k.store.InMemoryFeatureStore
@@ -17,8 +16,6 @@ import io.kotest.matchers.shouldBe
 
 /**
  * Tests for FF4kBuilder and ff4k() DSL entry point.
- *
- * @author Yonatan Karp-Rudin
  */
 internal class FF4kBuilderTest :
     FunSpec({

--- a/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/dsl/core/FlippingExecutionContextBuilderTest.kt
+++ b/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/dsl/core/FlippingExecutionContextBuilderTest.kt
@@ -7,8 +7,6 @@ import io.kotest.matchers.shouldBe
 
 /**
  * Tests for FlippingExecutionContextBuilder DSL.
- *
- * @author Yonatan Karp-Rudin
  */
 internal class FlippingExecutionContextBuilderTest :
     FunSpec({

--- a/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/dsl/feature/FeatureBuilderTest.kt
+++ b/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/dsl/feature/FeatureBuilderTest.kt
@@ -15,8 +15,6 @@ import io.kotest.matchers.shouldBe
 
 /**
  * Tests for FeatureBuilder DSL.
- *
- * @author Yonatan Karp-Rudin
  */
 internal class FeatureBuilderTest :
     FunSpec({

--- a/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/dsl/feature/FeaturesBuilderTest.kt
+++ b/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/dsl/feature/FeaturesBuilderTest.kt
@@ -9,8 +9,6 @@ import io.kotest.matchers.shouldBe
 
 /**
  * Tests for FeaturesBuilder DSL.
- *
- * @author Yonatan Karp-Rudin
  */
 internal class FeaturesBuilderTest :
     FunSpec({

--- a/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/dsl/feature/FeaturesDslTest.kt
+++ b/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/dsl/feature/FeaturesDslTest.kt
@@ -9,8 +9,6 @@ import io.kotest.matchers.shouldBe
 
 /**
  * Tests for top-level features() DSL function.
- *
- * @author Yonatan Karp-Rudin
  */
 internal class FeaturesDslTest :
     FunSpec({

--- a/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/dsl/property/FixedValuesBuilderTest.kt
+++ b/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/dsl/property/FixedValuesBuilderTest.kt
@@ -7,8 +7,6 @@ import io.kotest.matchers.shouldBe
 
 /**
  * Tests for FixedValuesBuilder DSL.
- *
- * @author Yonatan Karp-Rudin
  */
 internal class FixedValuesBuilderTest :
     FunSpec({

--- a/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/dsl/property/PropertiesBuilderTest.kt
+++ b/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/dsl/property/PropertiesBuilderTest.kt
@@ -11,8 +11,6 @@ import io.kotest.matchers.shouldBe
 
 /**
  * Tests for PropertiesBuilder DSL.
- *
- * @author Yonatan Karp-Rudin
  */
 internal class PropertiesBuilderTest :
     FunSpec({

--- a/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/dsl/property/PropertyBuilderTest.kt
+++ b/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/dsl/property/PropertyBuilderTest.kt
@@ -31,8 +31,6 @@ import kotlinx.datetime.LocalDateTime
 
 /**
  * Tests for PropertyBuilder DSL.
- *
- * @author Yonatan Karp-Rudin
  */
 internal class PropertyBuilderTest :
     FunSpec({

--- a/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/dsl/property/PropertyDslTest.kt
+++ b/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/dsl/property/PropertyDslTest.kt
@@ -10,8 +10,6 @@ import io.kotest.matchers.shouldBe
 
 /**
  * Tests for top-level property() and properties() DSL functions.
- *
- * @author Yonatan Karp-Rudin
  */
 internal class PropertyDslTest :
     FunSpec({

--- a/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/property/PropertyBigDecimalTest.kt
+++ b/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/property/PropertyBigDecimalTest.kt
@@ -9,8 +9,6 @@ import kotlinx.serialization.json.Json
 
 /**
  * Tests for PropertyBigDecimal class.
- *
- * @author Yonatan Karp-Rudin
  */
 internal class PropertyBigDecimalTest : PropertyContractTest<BigDecimal, PropertyBigDecimal>() {
 

--- a/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/property/PropertyBigIntegerTest.kt
+++ b/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/property/PropertyBigIntegerTest.kt
@@ -9,8 +9,6 @@ import kotlinx.serialization.json.Json
 
 /**
  * Tests for PropertyBigInteger class.
- *
- * @author Yonatan Karp-Rudin
  */
 internal class PropertyBigIntegerTest : PropertyContractTest<BigInteger, PropertyBigInteger>() {
 

--- a/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/property/PropertyBooleanTest.kt
+++ b/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/property/PropertyBooleanTest.kt
@@ -5,8 +5,6 @@ import io.kotest.matchers.shouldBe
 
 /**
  * Tests for PropertyBoolean class.
- *
- * @author Yonatan Karp-Rudin
  */
 internal class PropertyBooleanTest : PropertyContractTest<Boolean, PropertyBoolean>() {
 

--- a/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/property/PropertyByteTest.kt
+++ b/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/property/PropertyByteTest.kt
@@ -4,8 +4,6 @@ import com.yonatankarp.ff4k.test.contract.property.PropertyContractTest
 
 /**
  * Tests for PropertyByte class.
- *
- * @author Yonatan Karp-Rudin
  */
 internal class PropertyByteTest : PropertyContractTest<Byte, PropertyByte>() {
 

--- a/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/property/PropertyDoubleTest.kt
+++ b/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/property/PropertyDoubleTest.kt
@@ -4,8 +4,6 @@ import com.yonatankarp.ff4k.test.contract.property.PropertyContractTest
 
 /**
  * Tests for PropertyDouble class.
- *
- * @author Yonatan Karp-Rudin
  */
 internal class PropertyDoubleTest : PropertyContractTest<Double, PropertyDouble>() {
 

--- a/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/property/PropertyFloatTest.kt
+++ b/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/property/PropertyFloatTest.kt
@@ -4,8 +4,6 @@ import com.yonatankarp.ff4k.test.contract.property.PropertyContractTest
 
 /**
  * Tests for PropertyFloat class.
- *
- * @author Yonatan Karp-Rudin
  */
 internal class PropertyFloatTest : PropertyContractTest<Float, PropertyFloat>() {
 

--- a/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/property/PropertyInstantTest.kt
+++ b/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/property/PropertyInstantTest.kt
@@ -6,8 +6,6 @@ import kotlinx.datetime.Instant
 
 /**
  * Tests for PropertyInstant class.
- *
- * @author Yonatan Karp-Rudin
  */
 internal class PropertyInstantTest : PropertyContractTest<Instant, PropertyInstant>() {
 

--- a/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/property/PropertyIntTest.kt
+++ b/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/property/PropertyIntTest.kt
@@ -4,8 +4,6 @@ import com.yonatankarp.ff4k.test.contract.property.PropertyContractTest
 
 /**
  * Tests for PropertyInt class.
- *
- * @author Yonatan Karp-Rudin
  */
 internal class PropertyIntTest : PropertyContractTest<Int, PropertyInt>() {
 

--- a/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/property/PropertyLocalDateTest.kt
+++ b/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/property/PropertyLocalDateTest.kt
@@ -6,8 +6,6 @@ import kotlinx.datetime.LocalDate
 
 /**
  * Tests for PropertyLocalDate class.
- *
- * @author Yonatan Karp-Rudin
  */
 internal class PropertyLocalDateTest : PropertyContractTest<LocalDate, PropertyLocalDate>() {
 

--- a/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/property/PropertyLocalDateTimeTest.kt
+++ b/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/property/PropertyLocalDateTimeTest.kt
@@ -6,8 +6,6 @@ import kotlinx.datetime.LocalDateTime
 
 /**
  * Tests for PropertyLocalDateTime class.
- *
- * @author Yonatan Karp-Rudin
  */
 internal class PropertyLocalDateTimeTest : PropertyContractTest<LocalDateTime, PropertyLocalDateTime>() {
 

--- a/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/property/PropertyLogLevelTest.kt
+++ b/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/property/PropertyLogLevelTest.kt
@@ -6,8 +6,6 @@ import io.kotest.matchers.string.shouldContain
 
 /**
  * Tests for PropertyLogLevel class.
- *
- * @author Yonatan Karp-Rudin
  */
 internal class PropertyLogLevelTest : PropertyContractTest<LogLevel, PropertyLogLevel>() {
 

--- a/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/property/PropertyLongTest.kt
+++ b/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/property/PropertyLongTest.kt
@@ -4,8 +4,6 @@ import com.yonatankarp.ff4k.test.contract.property.PropertyContractTest
 
 /**
  * Tests for PropertyLong class.
- *
- * @author Yonatan Karp-Rudin
  */
 internal class PropertyLongTest : PropertyContractTest<Long, PropertyLong>() {
 

--- a/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/property/PropertyShortTest.kt
+++ b/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/property/PropertyShortTest.kt
@@ -4,8 +4,6 @@ import com.yonatankarp.ff4k.test.contract.property.PropertyContractTest
 
 /**
  * Tests for PropertyShort class.
- *
- * @author Yonatan Karp-Rudin
  */
 internal class PropertyShortTest : PropertyContractTest<Short, PropertyShort>() {
 

--- a/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/property/PropertyStringTest.kt
+++ b/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/property/PropertyStringTest.kt
@@ -5,8 +5,6 @@ import io.kotest.matchers.string.shouldContain
 
 /**
  * Tests for PropertyString class.
- *
- * @author Yonatan Karp-Rudin
  */
 internal class PropertyStringTest : PropertyContractTest<String, PropertyString>() {
 


### PR DESCRIPTION
Remove the `@author` tag from the codebase. Its purpose is already tracked by version control.