### PR TITLE
refactor: split StrategyDsl into focused files

### DIFF
--- a/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/dsl/strategy/FilterStrategyDsl.kt
+++ b/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/dsl/strategy/FilterStrategyDsl.kt
@@ -1,0 +1,97 @@
+package com.yonatankarp.ff4k.dsl.strategy
+
+import com.yonatankarp.ff4k.dsl.feature.FeatureBuilder
+import com.yonatankarp.ff4k.strategy.ClientFilterStrategy
+import com.yonatankarp.ff4k.strategy.RegionFilterStrategy
+import com.yonatankarp.ff4k.strategy.ServerFilterStrategy
+
+/**
+ * Configures a [ClientFilterStrategy] for this feature.
+ *
+ * The feature will be enabled only for requests from the specified client
+ * hostnames. Requires [com.yonatankarp.ff4k.core.ContextKeys.CLIENT_HOSTNAME]
+ * to be set in the [com.yonatankarp.ff4k.core.FlippingExecutionContext].
+ *
+ * ## Example
+ *
+ * ```kotlin
+ * feature("internal-only") {
+ *     clientFilterStrategy {
+ *         +"client-a.internal.com"
+ *         +"client-b.internal.com"
+ *     }
+ * }
+ * ```
+ *
+ * @param block A DSL block to configure the set of allowed client hostnames.
+ * @see serverFilterStrategy
+ * @see regionStrategy
+ * @author Yonatan Karp-Rudin
+ */
+fun FeatureBuilder.clientFilterStrategy(
+    block: ListBuilder.() -> Unit,
+) {
+    val grantedClients = ListBuilder().apply(block).build()
+    flippingStrategy = ClientFilterStrategy(grantedClients)
+}
+
+/**
+ * Configures a [ServerFilterStrategy] for this feature.
+ *
+ * The feature will be enabled only on the specified server hostnames.
+ * Useful for canary deployments or instance-specific feature toggles.
+ * Requires [com.yonatankarp.ff4k.core.ContextKeys.SERVER_HOSTNAME]
+ * to be set in the [com.yonatankarp.ff4k.core.FlippingExecutionContext].
+ *
+ * ## Example
+ *
+ * ```kotlin
+ * feature("canary-feature") {
+ *     serverFilterStrategy {
+ *         +"server-1.prod.com"
+ *         +"server-2.prod.com"
+ *     }
+ * }
+ * ```
+ *
+ * @param block A DSL block to configure the set of target server hostnames.
+ * @see clientFilterStrategy
+ * @see regionStrategy
+ * @author Yonatan Karp-Rudin
+ */
+fun FeatureBuilder.serverFilterStrategy(
+    block: ListBuilder.() -> Unit,
+) {
+    val targetServers = ListBuilder().apply(block).build()
+    flippingStrategy = ServerFilterStrategy(targetServers)
+}
+
+/**
+ * Configures a [RegionFilterStrategy] for this feature.
+ *
+ * The feature will be enabled only for the specified geographic regions.
+ * Requires [com.yonatankarp.ff4k.core.ContextKeys.REGION] to be set in the
+ * [com.yonatankarp.ff4k.core.FlippingExecutionContext].
+ *
+ * ## Example
+ *
+ * ```kotlin
+ * feature("eu-only") {
+ *     regionStrategy {
+ *         +"eu-central-1"
+ *         +"eu-west-1"
+ *     }
+ * }
+ * ```
+ *
+ * @param block A DSL block to configure the set of allowed regions.
+ * @see clientFilterStrategy
+ * @see serverFilterStrategy
+ * @author Yonatan Karp-Rudin
+ */
+fun FeatureBuilder.regionStrategy(
+    block: ListBuilder.() -> Unit,
+) {
+    val allowedRegions = ListBuilder().apply(block).build()
+    flippingStrategy = RegionFilterStrategy(allowedRegions)
+}

--- a/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/dsl/strategy/ListStrategyDsl.kt
+++ b/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/dsl/strategy/ListStrategyDsl.kt
@@ -1,0 +1,59 @@
+package com.yonatankarp.ff4k.dsl.strategy
+
+import com.yonatankarp.ff4k.dsl.feature.FeatureBuilder
+import com.yonatankarp.ff4k.strategy.AllowListStrategy
+import com.yonatankarp.ff4k.strategy.DenyListStrategy
+
+/**
+ * Configures an [AllowListStrategy] for this feature.
+ *
+ * Only users whose ID is in the allow list will have the feature enabled.
+ * Requires `userId` to be set in the [com.yonatankarp.ff4k.core.FlippingExecutionContext].
+ *
+ * ## Example
+ *
+ * ```kotlin
+ * feature("vip-feature") {
+ *     allowListStrategy {
+ *         +"user-123"
+ *         +"user-456"
+ *         add("user-789")
+ *     }
+ * }
+ * ```
+ *
+ * @param block A DSL block to configure the list of allowed user IDs.
+ * @see denyListStrategy for the inverse behavior
+ * @author Yonatan Karp-Rudin
+ */
+fun FeatureBuilder.allowListStrategy(block: ListBuilder.() -> Unit) {
+    val list = ListBuilder().apply(block).build()
+    flippingStrategy = AllowListStrategy(list)
+}
+
+/**
+ * Configures a [DenyListStrategy] for this feature.
+ *
+ * Users whose ID is in the deny list will have the feature disabled;
+ * all other users will have it enabled. Requires `userId` to be set in the
+ * [com.yonatankarp.ff4k.core.FlippingExecutionContext].
+ *
+ * ## Example
+ *
+ * ```kotlin
+ * feature("new-ui") {
+ *     denyListStrategy {
+ *         +"problematic-user-1"
+ *         +"problematic-user-2"
+ *     }
+ * }
+ * ```
+ *
+ * @param block A DSL block to configure the list of denied user IDs.
+ * @see allowListStrategy for the inverse behavior
+ * @author Yonatan Karp-Rudin
+ */
+fun FeatureBuilder.denyListStrategy(block: ListBuilder.() -> Unit) {
+    val list = ListBuilder().apply(block).build()
+    flippingStrategy = DenyListStrategy(list)
+}

--- a/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/dsl/strategy/RolloutStrategyDsl.kt
+++ b/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/dsl/strategy/RolloutStrategyDsl.kt
@@ -1,0 +1,99 @@
+package com.yonatankarp.ff4k.dsl.strategy
+
+import com.yonatankarp.ff4k.dsl.feature.FeatureBuilder
+import com.yonatankarp.ff4k.strategy.PonderationStrategy
+import com.yonatankarp.ff4k.strategy.UserPonderationStrategy
+
+/**
+ * Configures a [PonderationStrategy] for this feature with a decimal weight.
+ *
+ * Each evaluation is independent - the same user may get different results
+ * on subsequent calls.
+ *
+ * ## Example
+ *
+ * ```kotlin
+ * feature("gradual-rollout") {
+ *     ponderationStrategy(0.25) // 25% chance of being enabled
+ * }
+ * ```
+ *
+ * @param weight The probability (0.0 to 1.0) that the feature is enabled.
+ * @throws IllegalArgumentException if weight is not in range 0.0..1.0
+ * @see userPonderationStrategy for user-sticky behavior
+ * @author Yonatan Karp-Rudin
+ */
+fun FeatureBuilder.ponderationStrategy(weight: Double) {
+    flippingStrategy = PonderationStrategy(weight)
+}
+
+/**
+ * Configures a [PonderationStrategy] for this feature with an integer percentage.
+ *
+ * Each evaluation is independent - the same user may get different results
+ * on subsequent calls.
+ *
+ * ## Example
+ *
+ * ```kotlin
+ * feature("gradual-rollout") {
+ *     ponderationStrategy(25) // 25% chance of being enabled
+ * }
+ * ```
+ *
+ * @param weight The percentage (0 to 100) that the feature is enabled.
+ * @throws IllegalArgumentException if weight is not in range 0..100
+ * @see userPonderationStrategy for user-sticky behavior
+ * @author Yonatan Karp-Rudin
+ */
+fun FeatureBuilder.ponderationStrategy(weight: Int) {
+    flippingStrategy = PonderationStrategy(weight)
+}
+
+/**
+ * Configures a [UserPonderationStrategy] for this feature with a decimal weight.
+ *
+ * Unlike [ponderationStrategy], this strategy is deterministic per user -
+ * the same user will always get the same result. Requires `userId` to be
+ * set in the [com.yonatankarp.ff4k.core.FlippingExecutionContext].
+ *
+ * ## Example
+ *
+ * ```kotlin
+ * feature("beta-feature") {
+ *     userPonderationStrategy(0.1) // 10% of users will have access
+ * }
+ * ```
+ *
+ * @param weight The probability (0.0 to 1.0) of users for whom the feature is enabled.
+ * @throws IllegalArgumentException if weight is not in range 0.0..1.0
+ * @see ponderationStrategy for random (non-sticky) behavior
+ * @author Yonatan Karp-Rudin
+ */
+fun FeatureBuilder.userPonderationStrategy(weight: Double) {
+    flippingStrategy = UserPonderationStrategy(weight)
+}
+
+/**
+ * Configures a [UserPonderationStrategy] for this feature with an integer percentage.
+ *
+ * Unlike [ponderationStrategy], this strategy is deterministic per user -
+ * the same user will always get the same result. Requires `userId` to be
+ * set in the [com.yonatankarp.ff4k.core.FlippingExecutionContext].
+ *
+ * ## Example
+ *
+ * ```kotlin
+ * feature("beta-feature") {
+ *     userPonderationStrategy(10) // 10% of users will have access
+ * }
+ * ```
+ *
+ * @param weight The percentage (0 to 100) of users for whom the feature is enabled.
+ * @throws IllegalArgumentException if weight is not in range 0..100
+ * @see ponderationStrategy for random (non-sticky) behavior
+ * @author Yonatan Karp-Rudin
+ */
+fun FeatureBuilder.userPonderationStrategy(weight: Int) {
+    flippingStrategy = UserPonderationStrategy(weight)
+}

--- a/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/dsl/strategy/TimeStrategyDsl.kt
+++ b/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/dsl/strategy/TimeStrategyDsl.kt
@@ -1,163 +1,14 @@
 package com.yonatankarp.ff4k.dsl.strategy
 
 import com.yonatankarp.ff4k.dsl.feature.FeatureBuilder
-import com.yonatankarp.ff4k.strategy.AllowListStrategy
-import com.yonatankarp.ff4k.strategy.ClientFilterStrategy
 import com.yonatankarp.ff4k.strategy.DailyHoursStrategy
 import com.yonatankarp.ff4k.strategy.DateRangeStrategy
-import com.yonatankarp.ff4k.strategy.DenyListStrategy
-import com.yonatankarp.ff4k.strategy.PonderationStrategy
-import com.yonatankarp.ff4k.strategy.RegionFilterStrategy
 import com.yonatankarp.ff4k.strategy.ReleaseDateStrategy
-import com.yonatankarp.ff4k.strategy.ServerFilterStrategy
-import com.yonatankarp.ff4k.strategy.UserPonderationStrategy
 import com.yonatankarp.ff4k.strategy.WeekdayStrategy
 import kotlinx.datetime.Instant
 import kotlinx.datetime.LocalDateTime
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toInstant
-
-/**
- * Configures a [PonderationStrategy] for this feature with a decimal weight.
- *
- * Each evaluation is independent - the same user may get different results
- * on subsequent calls.
- *
- * ## Example
- *
- * ```kotlin
- * feature("gradual-rollout") {
- *     ponderationStrategy(0.25) // 25% chance of being enabled
- * }
- * ```
- *
- * @param weight The probability (0.0 to 1.0) that the feature is enabled.
- * @throws IllegalArgumentException if weight is not in range 0.0..1.0
- * @see userPonderationStrategy for user-sticky behavior
- */
-fun FeatureBuilder.ponderationStrategy(weight: Double) {
-    flippingStrategy = PonderationStrategy(weight)
-}
-
-/**
- * Configures a [PonderationStrategy] for this feature with an integer percentage.
- *
- * Each evaluation is independent - the same user may get different results
- * on subsequent calls.
- *
- * ## Example
- *
- * ```kotlin
- * feature("gradual-rollout") {
- *     ponderationStrategy(25) // 25% chance of being enabled
- * }
- * ```
- *
- * @param weight The percentage (0 to 100) that the feature is enabled.
- * @throws IllegalArgumentException if weight is not in range 0..100
- * @see userPonderationStrategy for user-sticky behavior
- */
-fun FeatureBuilder.ponderationStrategy(weight: Int) {
-    flippingStrategy = PonderationStrategy(weight)
-}
-
-/**
- * Configures a [UserPonderationStrategy] for this feature with a decimal weight.
- *
- * Unlike [ponderationStrategy], this strategy is deterministic per user -
- * the same user will always get the same result. Requires `userId` to be
- * set in the [com.yonatankarp.ff4k.core.FlippingExecutionContext].
- *
- * ## Example
- *
- * ```kotlin
- * feature("beta-feature") {
- *     userPonderationStrategy(0.1) // 10% of users will have access
- * }
- * ```
- *
- * @param weight The probability (0.0 to 1.0) of users for whom the feature is enabled.
- * @throws IllegalArgumentException if weight is not in range 0.0..1.0
- * @see ponderationStrategy for random (non-sticky) behavior
- */
-fun FeatureBuilder.userPonderationStrategy(weight: Double) {
-    flippingStrategy = UserPonderationStrategy(weight)
-}
-
-/**
- * Configures a [UserPonderationStrategy] for this feature with an integer percentage.
- *
- * Unlike [ponderationStrategy], this strategy is deterministic per user -
- * the same user will always get the same result. Requires `userId` to be
- * set in the [com.yonatankarp.ff4k.core.FlippingExecutionContext].
- *
- * ## Example
- *
- * ```kotlin
- * feature("beta-feature") {
- *     userPonderationStrategy(10) // 10% of users will have access
- * }
- * ```
- *
- * @param weight The percentage (0 to 100) of users for whom the feature is enabled.
- * @throws IllegalArgumentException if weight is not in range 0..100
- * @see ponderationStrategy for random (non-sticky) behavior
- */
-fun FeatureBuilder.userPonderationStrategy(weight: Int) {
-    flippingStrategy = UserPonderationStrategy(weight)
-}
-
-/**
- * Configures an [AllowListStrategy] for this feature.
- *
- * Only users whose ID is in the allow list will have the feature enabled.
- * Requires `userId` to be set in the [com.yonatankarp.ff4k.core.FlippingExecutionContext].
- *
- * ## Example
- *
- * ```kotlin
- * feature("vip-feature") {
- *     allowListStrategy {
- *         +"user-123"
- *         +"user-456"
- *         add("user-789")
- *     }
- * }
- * ```
- *
- * @param block A DSL block to configure the list of allowed user IDs.
- * @see denyListStrategy for the inverse behavior
- */
-fun FeatureBuilder.allowListStrategy(block: ListBuilder.() -> Unit) {
-    val list = ListBuilder().apply(block).build()
-    flippingStrategy = AllowListStrategy(list)
-}
-
-/**
- * Configures a [DenyListStrategy] for this feature.
- *
- * Users whose ID is in the deny list will have the feature disabled;
- * all other users will have it enabled. Requires `userId` to be set in the
- * [com.yonatankarp.ff4k.core.FlippingExecutionContext].
- *
- * ## Example
- *
- * ```kotlin
- * feature("new-ui") {
- *     denyListStrategy {
- *         +"problematic-user-1"
- *         +"problematic-user-2"
- *     }
- * }
- * ```
- *
- * @param block A DSL block to configure the list of denied user IDs.
- * @see allowListStrategy for the inverse behavior
- */
-fun FeatureBuilder.denyListStrategy(block: ListBuilder.() -> Unit) {
-    val list = ListBuilder().apply(block).build()
-    flippingStrategy = DenyListStrategy(list)
-}
 
 /**
  * Configures a [ReleaseDateStrategy] for this feature using an [Instant].
@@ -175,6 +26,7 @@ fun FeatureBuilder.denyListStrategy(block: ListBuilder.() -> Unit) {
  *
  * @param releaseDate The instant after which the feature becomes enabled.
  * @see dateRangeStrategy for enabling a feature within a time window
+ * @author Yonatan Karp-Rudin
  */
 fun FeatureBuilder.releaseDateStrategy(releaseDate: Instant) {
     flippingStrategy = ReleaseDateStrategy(releaseDate)
@@ -197,6 +49,7 @@ fun FeatureBuilder.releaseDateStrategy(releaseDate: Instant) {
  * @param date The release date in ISO-8601 format (e.g., "2025-01-01T00:00:00Z").
  * @throws IllegalArgumentException if the date string is not valid ISO-8601 format.
  * @see dateRangeStrategy for enabling a feature within a time window
+ * @author Yonatan Karp-Rudin
  */
 fun FeatureBuilder.releaseDateStrategy(date: String) {
     flippingStrategy = ReleaseDateStrategy(Instant.parse(date))
@@ -222,6 +75,7 @@ fun FeatureBuilder.releaseDateStrategy(date: String) {
  * @param dateTime The local date and time of the release.
  * @param timezone The timezone to interpret the local date time. Defaults to UTC.
  * @see dateRangeStrategy for enabling a feature within a time window
+ * @author Yonatan Karp-Rudin
  */
 fun FeatureBuilder.releaseDateStrategy(
     dateTime: LocalDateTime,
@@ -250,6 +104,7 @@ fun FeatureBuilder.releaseDateStrategy(
  * @param startDate The instant from which the feature becomes enabled (inclusive).
  * @param endDate The instant at which the feature becomes disabled (exclusive).
  * @see releaseDateStrategy for enabling a feature after a single date
+ * @author Yonatan Karp-Rudin
  */
 fun FeatureBuilder.dateRangeStrategy(startDate: Instant, endDate: Instant) {
     flippingStrategy = DateRangeStrategy(startDate, endDate)
@@ -276,6 +131,7 @@ fun FeatureBuilder.dateRangeStrategy(startDate: Instant, endDate: Instant) {
  * @param endDate The end date in ISO-8601 format (e.g., "2025-01-31T23:59:59Z").
  * @throws IllegalArgumentException if either date string is not valid ISO-8601 format.
  * @see releaseDateStrategy for enabling a feature after a single date
+ * @author Yonatan Karp-Rudin
  */
 fun FeatureBuilder.dateRangeStrategy(startDate: String, endDate: String) {
     flippingStrategy = DateRangeStrategy(
@@ -306,6 +162,7 @@ fun FeatureBuilder.dateRangeStrategy(startDate: String, endDate: String) {
  * @param endDate The local date and time when the feature becomes disabled.
  * @param timezone The timezone to interpret the local date times. Defaults to UTC.
  * @see releaseDateStrategy for enabling a feature after a single date
+ * @author Yonatan Karp-Rudin
  */
 fun FeatureBuilder.dateRangeStrategy(
     startDate: LocalDateTime,
@@ -342,6 +199,7 @@ fun FeatureBuilder.dateRangeStrategy(
  * @throws IllegalArgumentException if startHour is not in 0..23, endHour is not in 1..24,
  *         or endHour is not greater than startHour.
  * @see weekdayStrategy for day-of-week based enabling
+ * @author Yonatan Karp-Rudin
  */
 fun FeatureBuilder.dailyHoursStrategy(
     startHour: Int,
@@ -374,6 +232,7 @@ fun FeatureBuilder.dailyHoursStrategy(
  * @param timezone The timezone to use for day calculations. Defaults to UTC.
  * @param block A DSL block to configure the allowed days of the week.
  * @see dailyHoursStrategy for hour-based enabling
+ * @author Yonatan Karp-Rudin
  */
 fun FeatureBuilder.weekdayStrategy(
     timezone: TimeZone = TimeZone.UTC,
@@ -381,92 +240,4 @@ fun FeatureBuilder.weekdayStrategy(
 ) {
     val days = WeekdayBuilder().apply(block).build()
     flippingStrategy = WeekdayStrategy(days, timezone)
-}
-
-/**
- * Configures a [ClientFilterStrategy] for this feature.
- *
- * The feature will be enabled only for requests from the specified client
- * hostnames. Requires [com.yonatankarp.ff4k.core.ContextKeys.CLIENT_HOSTNAME]
- * to be set in the [com.yonatankarp.ff4k.core.FlippingExecutionContext].
- *
- * ## Example
- *
- * ```kotlin
- * feature("internal-only") {
- *     clientFilterStrategy {
- *         +"client-a.internal.com"
- *         +"client-b.internal.com"
- *     }
- * }
- * ```
- *
- * @param block A DSL block to configure the set of allowed client hostnames.
- * @see serverFilterStrategy
- * @see regionStrategy
- */
-fun FeatureBuilder.clientFilterStrategy(
-    block: ListBuilder.() -> Unit,
-) {
-    val grantedClients = ListBuilder().apply(block).build()
-    flippingStrategy = ClientFilterStrategy(grantedClients)
-}
-
-/**
- * Configures a [ServerFilterStrategy] for this feature.
- *
- * The feature will be enabled only on the specified server hostnames.
- * Useful for canary deployments or instance-specific feature toggles.
- * Requires [com.yonatankarp.ff4k.core.ContextKeys.SERVER_HOSTNAME]
- * to be set in the [com.yonatankarp.ff4k.core.FlippingExecutionContext].
- *
- * ## Example
- *
- * ```kotlin
- * feature("canary-feature") {
- *     serverFilterStrategy {
- *         +"server-1.prod.com"
- *         +"server-2.prod.com"
- *     }
- * }
- * ```
- *
- * @param block A DSL block to configure the set of target server hostnames.
- * @see clientFilterStrategy
- * @see regionStrategy
- */
-fun FeatureBuilder.serverFilterStrategy(
-    block: ListBuilder.() -> Unit,
-) {
-    val targetServers = ListBuilder().apply(block).build()
-    flippingStrategy = ServerFilterStrategy(targetServers)
-}
-
-/**
- * Configures a [RegionFilterStrategy] for this feature.
- *
- * The feature will be enabled only for the specified geographic regions.
- * Requires [com.yonatankarp.ff4k.core.ContextKeys.REGION] to be set in the
- * [com.yonatankarp.ff4k.core.FlippingExecutionContext].
- *
- * ## Example
- *
- * ```kotlin
- * feature("eu-only") {
- *     regionStrategy {
- *         +"eu-central-1"
- *         +"eu-west-1"
- *     }
- * }
- * ```
- *
- * @param block A DSL block to configure the set of allowed regions.
- * @see clientFilterStrategy
- * @see serverFilterStrategy
- */
-fun FeatureBuilder.regionStrategy(
-    block: ListBuilder.() -> Unit,
-) {
-    val allowedRegions = ListBuilder().apply(block).build()
-    flippingStrategy = RegionFilterStrategy(allowedRegions)
 }

--- a/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/dsl/strategy/FilterStrategyDslTest.kt
+++ b/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/dsl/strategy/FilterStrategyDslTest.kt
@@ -1,0 +1,52 @@
+package com.yonatankarp.ff4k.dsl.strategy
+
+import com.yonatankarp.ff4k.dsl.feature.feature
+import com.yonatankarp.ff4k.strategy.ClientFilterStrategy
+import com.yonatankarp.ff4k.strategy.RegionFilterStrategy
+import com.yonatankarp.ff4k.strategy.ServerFilterStrategy
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * @author Yonatan Karp-Rudin
+ */
+internal class FilterStrategyDslTest :
+    FunSpec({
+
+        test("clientFilterStrategy sets ClientFilterStrategy") {
+            val feature = feature("test") {
+                clientFilterStrategy {
+                    +"client-a"
+                    +"client-b"
+                }
+            }
+
+            feature.flippingStrategy.shouldBeInstanceOf<ClientFilterStrategy>()
+            feature.flippingStrategy.grantedClients shouldContainExactlyInAnyOrder listOf("client-a", "client-b")
+        }
+
+        test("serverFilterStrategy sets ServerFilterStrategy") {
+            val feature = feature("test") {
+                serverFilterStrategy {
+                    +"server-1"
+                    +"server-2"
+                }
+            }
+
+            feature.flippingStrategy.shouldBeInstanceOf<ServerFilterStrategy>()
+            feature.flippingStrategy.targetServers shouldContainExactlyInAnyOrder listOf("server-1", "server-2")
+        }
+
+        test("regionStrategy sets RegionFilterStrategy") {
+            val feature = feature("test") {
+                regionStrategy {
+                    +"eu-central-1"
+                    +"us-west-2"
+                }
+            }
+
+            feature.flippingStrategy.shouldBeInstanceOf<RegionFilterStrategy>()
+            feature.flippingStrategy.grantedRegions shouldContainExactlyInAnyOrder listOf("eu-central-1", "us-west-2")
+        }
+    })

--- a/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/dsl/strategy/ListStrategyDslTest.kt
+++ b/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/dsl/strategy/ListStrategyDslTest.kt
@@ -1,0 +1,39 @@
+package com.yonatankarp.ff4k.dsl.strategy
+
+import com.yonatankarp.ff4k.dsl.feature.feature
+import com.yonatankarp.ff4k.strategy.AllowListStrategy
+import com.yonatankarp.ff4k.strategy.DenyListStrategy
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * @author Yonatan Karp-Rudin
+ */
+internal class ListStrategyDslTest :
+    FunSpec({
+
+        test("allowListStrategy sets AllowListStrategy") {
+            val feature = feature("test") {
+                allowListStrategy {
+                    +"user-1"
+                    +"user-2"
+                }
+            }
+
+            feature.flippingStrategy.shouldBeInstanceOf<AllowListStrategy>()
+            feature.flippingStrategy.allowedList shouldContainExactlyInAnyOrder listOf("user-1", "user-2")
+        }
+
+        test("denyListStrategy sets DenyListStrategy") {
+            val feature = feature("test") {
+                denyListStrategy {
+                    +"user-1"
+                    +"user-2"
+                }
+            }
+
+            feature.flippingStrategy.shouldBeInstanceOf<DenyListStrategy>()
+            feature.flippingStrategy.denyList shouldContainExactlyInAnyOrder listOf("user-1", "user-2")
+        }
+    })

--- a/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/dsl/strategy/RolloutStrategyDslTest.kt
+++ b/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/dsl/strategy/RolloutStrategyDslTest.kt
@@ -1,0 +1,51 @@
+package com.yonatankarp.ff4k.dsl.strategy
+
+import com.yonatankarp.ff4k.dsl.feature.feature
+import com.yonatankarp.ff4k.strategy.PonderationStrategy
+import com.yonatankarp.ff4k.strategy.UserPonderationStrategy
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * @author Yonatan Karp-Rudin
+ */
+internal class RolloutStrategyDslTest :
+    FunSpec({
+
+        test("ponderationStrategy with Double sets strategy") {
+            val feature = feature("test") {
+                ponderationStrategy(0.75)
+            }
+
+            feature.flippingStrategy.shouldBeInstanceOf<PonderationStrategy>()
+            feature.flippingStrategy.weight shouldBe 0.75
+        }
+
+        test("ponderationStrategy with Int sets strategy") {
+            val feature = feature("test") {
+                ponderationStrategy(50)
+            }
+
+            feature.flippingStrategy.shouldBeInstanceOf<PonderationStrategy>()
+            feature.flippingStrategy.weight shouldBe 0.5
+        }
+
+        test("userPonderationStrategy with Double sets strategy") {
+            val feature = feature("test") {
+                userPonderationStrategy(0.75)
+            }
+
+            feature.flippingStrategy.shouldBeInstanceOf<UserPonderationStrategy>()
+            feature.flippingStrategy.weight shouldBe 0.75
+        }
+
+        test("userPonderationStrategy with Int sets strategy") {
+            val feature = feature("test") {
+                userPonderationStrategy(50)
+            }
+
+            feature.flippingStrategy.shouldBeInstanceOf<UserPonderationStrategy>()
+            feature.flippingStrategy.weight shouldBe 0.5
+        }
+    })

--- a/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/dsl/strategy/TimeStrategyDslTest.kt
+++ b/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/dsl/strategy/TimeStrategyDslTest.kt
@@ -1,16 +1,9 @@
 package com.yonatankarp.ff4k.dsl.strategy
 
 import com.yonatankarp.ff4k.dsl.feature.feature
-import com.yonatankarp.ff4k.strategy.AllowListStrategy
-import com.yonatankarp.ff4k.strategy.ClientFilterStrategy
 import com.yonatankarp.ff4k.strategy.DailyHoursStrategy
 import com.yonatankarp.ff4k.strategy.DateRangeStrategy
-import com.yonatankarp.ff4k.strategy.DenyListStrategy
-import com.yonatankarp.ff4k.strategy.PonderationStrategy
-import com.yonatankarp.ff4k.strategy.RegionFilterStrategy
 import com.yonatankarp.ff4k.strategy.ReleaseDateStrategy
-import com.yonatankarp.ff4k.strategy.ServerFilterStrategy
-import com.yonatankarp.ff4k.strategy.UserPonderationStrategy
 import com.yonatankarp.ff4k.strategy.WeekdayStrategy
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
@@ -22,104 +15,11 @@ import kotlinx.datetime.LocalDateTime
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toInstant
 
-internal class StrategyDslTest :
+/**
+ * @author Yonatan Karp-Rudin
+ */
+internal class TimeStrategyDslTest :
     FunSpec({
-
-        test("ponderationStrategy with Double sets strategy") {
-            val feature = feature("test") {
-                ponderationStrategy(0.75)
-            }
-
-            feature.flippingStrategy.shouldBeInstanceOf<PonderationStrategy>()
-            feature.flippingStrategy.weight shouldBe 0.75
-        }
-
-        test("ponderationStrategy with Int sets strategy") {
-            val feature = feature("test") {
-                ponderationStrategy(50)
-            }
-
-            feature.flippingStrategy.shouldBeInstanceOf<PonderationStrategy>()
-            feature.flippingStrategy.weight shouldBe 0.5
-        }
-
-        test("userPonderationStrategy with Double sets strategy") {
-            val feature = feature("test") {
-                userPonderationStrategy(0.75)
-            }
-
-            feature.flippingStrategy.shouldBeInstanceOf<UserPonderationStrategy>()
-            feature.flippingStrategy.weight shouldBe 0.75
-        }
-
-        test("userPonderationStrategy with Int sets strategy") {
-            val feature = feature("test") {
-                userPonderationStrategy(50)
-            }
-
-            feature.flippingStrategy.shouldBeInstanceOf<UserPonderationStrategy>()
-            feature.flippingStrategy.weight shouldBe 0.5
-        }
-
-        test("allowListStrategy sets AllowListStrategy") {
-            val feature = feature("test") {
-                allowListStrategy {
-                    +"user-1"
-                    +"user-2"
-                }
-            }
-
-            feature.flippingStrategy.shouldBeInstanceOf<AllowListStrategy>()
-            feature.flippingStrategy.allowedList shouldContainExactlyInAnyOrder listOf("user-1", "user-2")
-        }
-
-        test("denyListStrategy sets DenyListStrategy") {
-            val feature = feature("test") {
-                denyListStrategy {
-                    +"user-1"
-                    +"user-2"
-                }
-            }
-
-            feature.flippingStrategy.shouldBeInstanceOf<DenyListStrategy>()
-            feature.flippingStrategy.denyList shouldContainExactlyInAnyOrder listOf("user-1", "user-2")
-        }
-
-        test("clientFilterStrategy sets ClientFilterStrategy") {
-            val feature = feature("test") {
-                clientFilterStrategy {
-                    +"client-a"
-                    +"client-b"
-                }
-            }
-
-            feature.flippingStrategy.shouldBeInstanceOf<ClientFilterStrategy>()
-            feature.flippingStrategy.grantedClients shouldContainExactlyInAnyOrder listOf("client-a", "client-b")
-        }
-
-        test("serverFilterStrategy sets ServerFilterStrategy") {
-            val feature = feature("test") {
-                serverFilterStrategy {
-                    +"server-1"
-                    +"server-2"
-                }
-            }
-
-            feature.flippingStrategy.shouldBeInstanceOf<ServerFilterStrategy>()
-            feature.flippingStrategy.targetServers shouldContainExactlyInAnyOrder listOf("server-1", "server-2")
-        }
-
-        test("regionStrategy sets RegionFilterStrategy") {
-            val feature = feature("test") {
-                regionStrategy {
-                    +"eu-central-1"
-                    +"us-west-2"
-                }
-            }
-
-            feature.flippingStrategy.shouldBeInstanceOf<RegionFilterStrategy>()
-            feature.flippingStrategy.grantedRegions shouldContainExactlyInAnyOrder listOf("eu-central-1", "us-west-2")
-        }
 
         context("releaseDateStrategy") {
             test("sets ReleaseDateStrategy with Instant") {


### PR DESCRIPTION
## Summary

Refactored the monolithic `StrategyDsl` implementation and tests into focused, category-specific files. This splits the large DSL file into four smaller, logical units without changing any internal logic.

## Motivation

`StrategyDsl.kt` was approaching 500 lines and contained extension functions for every supported strategy type. Splitting it improves code organization, navigability, and maintainability, preventing it from becoming a "God file" as the library grows.

## Changes

<!-- What does this PR do? List the main changes -->

   - Split StrategyDsl.kt into:
     - TimeStrategyDsl.kt (Date/Time based strategies)
     - RolloutStrategyDsl.kt (Ponderation strategies)
     - FilterStrategyDsl.kt (Client/Server/Region filters)
     - ListStrategyDsl.kt (Allow/Deny lists)
   - Split StrategyDslTest.kt into corresponding test files to match the production code structure.


## Testing

<!-- How did you test these changes? -->

- [X] Unit tests added/updated
- [x] Tested on JVM
- [X] Tested on Android
- [X] Tested on iOS

## Checklist

- [X] My code follows the project's code style (`./gradlew spotlessCheck` passes)
- [X] I have added tests that prove my fix/feature works
- [X] All tests pass (`./gradlew check`)
- [ ] I have updated documentation if needed
- [ ] I marked all checkboxes without reading


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added filter strategy configuration options for client, server, and region-based feature control.
  * Introduced allow/deny list strategy configuration via DSL.
  * Added rollout strategy configuration for percentage-based deployments with user-deterministic variants.

* **Tests**
  * Added comprehensive test coverage for new strategy DSL capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->