### PR TITLE
refactor(core): use parameterized tests for strategies

### DIFF
--- a/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/strategy/AllowListStrategyTest.kt
+++ b/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/strategy/AllowListStrategyTest.kt
@@ -6,6 +6,7 @@ import com.yonatankarp.ff4k.core.FlippingStrategy
 import com.yonatankarp.ff4k.serialization.FF4kJson
 import com.yonatankarp.ff4k.store.InMemoryFeatureStore
 import com.yonatankarp.ff4k.test.contract.strategy.FlippingStrategyContractTest
+import io.kotest.datatest.withData
 import io.kotest.matchers.booleans.shouldBeFalse
 import io.kotest.matchers.booleans.shouldBeTrue
 import io.kotest.matchers.shouldBe
@@ -28,16 +29,27 @@ internal class AllowListStrategyTest :
                 result.shouldBeFalse()
             }
 
-            test("returns true only for users in the allow list") {
-                // Given
-                val strategy = AllowListStrategy(setOf("Alice", "Charlie"))
-                val store = InMemoryFeatureStore()
+            context("returns true only for users in the allow list") {
+                withData(
+                    AllowListTestCase("Alice", true),
+                    AllowListTestCase("Charlie", true),
+                    AllowListTestCase("Bob", false),
+                    AllowListTestCase("David", false),
+                ) { (user, shouldBeAllowed) ->
+                    // Given
+                    val strategy = AllowListStrategy(setOf("Alice", "Charlie"))
+                    val store = InMemoryFeatureStore()
 
-                // When / Then
-                strategy.evaluate("test", store, FlippingExecutionContext(ContextKeys.USER_ID to "Alice")).shouldBeTrue()
-                strategy.evaluate("test", store, FlippingExecutionContext(ContextKeys.USER_ID to "Charlie")).shouldBeTrue()
-                strategy.evaluate("test", store, FlippingExecutionContext(ContextKeys.USER_ID to "Bob")).shouldBeFalse()
-                strategy.evaluate("test", store, FlippingExecutionContext(ContextKeys.USER_ID to "David")).shouldBeFalse()
+                    // When
+                    val result = strategy.evaluate(
+                        "test",
+                        store,
+                        FlippingExecutionContext(ContextKeys.USER_ID to user),
+                    )
+
+                    // Then
+                    result shouldBe shouldBeAllowed
+                }
             }
 
             test("handles null feature store") {
@@ -93,3 +105,5 @@ internal class AllowListStrategyTest :
 
     override fun requiredContextKeys(): Set<String> = setOf(ContextKeys.USER_ID)
 }
+
+private data class AllowListTestCase(val user: String, val shouldBeAllowed: Boolean)

--- a/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/strategy/DailyHoursStrategyTest.kt
+++ b/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/strategy/DailyHoursStrategyTest.kt
@@ -6,8 +6,10 @@ import com.yonatankarp.ff4k.store.InMemoryFeatureStore
 import com.yonatankarp.ff4k.test.contract.strategy.FlippingStrategyContractTest
 import com.yonatankarp.ff4k.utils.fixedClock
 import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.datatest.withData
 import io.kotest.matchers.booleans.shouldBeFalse
 import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.shouldBe
 import kotlinx.datetime.Instant
 import kotlinx.datetime.TimeZone
 
@@ -15,9 +17,21 @@ internal class DailyHoursStrategyTest :
     FlippingStrategyContractTest({
 
         context("evaluate boundary conditions") {
-            test("returns true when current hour equals startHour (inclusive)") {
-                // Given - 10:00 UTC
-                val strategy = createStrategy(currentTime = "2025-01-15T10:00:00Z")
+            withData(
+                nameFn = { "time: ${it.currentTime} -> expect: ${it.shouldBeEnabled}" },
+                // 10:00 start (inclusive)
+                DailyHoursEvaluationTestCase("2025-01-15T10:00:00Z", true),
+                // 14:00 end (exclusive)
+                DailyHoursEvaluationTestCase("2025-01-15T14:00:00Z", false),
+                // 12:30 in range
+                DailyHoursEvaluationTestCase("2025-01-15T12:30:00Z", true),
+                // 09:59 before start
+                DailyHoursEvaluationTestCase("2025-01-15T09:59:59Z", false),
+                // 15:00 after end
+                DailyHoursEvaluationTestCase("2025-01-15T15:00:00Z", false),
+            ) { (currentTime, shouldBeEnabled) ->
+                // Given - range 10:00 to 14:00
+                val strategy = createStrategy(currentTime = currentTime)
 
                 // When
                 val result = strategy.evaluate(
@@ -27,67 +41,7 @@ internal class DailyHoursStrategyTest :
                 )
 
                 // Then
-                result.shouldBeTrue()
-            }
-
-            test("returns false when current hour equals endHour (exclusive)") {
-                // Given - 14:00 UTC
-                val strategy = createStrategy(currentTime = "2025-01-15T14:00:00Z")
-
-                // When
-                val result = strategy.evaluate(
-                    featureId = "test",
-                    store = InMemoryFeatureStore(),
-                    context = FlippingExecutionContext(),
-                )
-
-                // Then
-                result.shouldBeFalse()
-            }
-
-            test("returns true when current hour is within range") {
-                // Given - 12:30 UTC
-                val strategy = createStrategy(currentTime = "2025-01-15T12:30:00Z")
-
-                // When
-                val result = strategy.evaluate(
-                    featureId = "test",
-                    store = InMemoryFeatureStore(),
-                    context = FlippingExecutionContext(),
-                )
-
-                // Then
-                result.shouldBeTrue()
-            }
-
-            test("returns false when current hour is before startHour") {
-                // Given - 09:59 UTC
-                val strategy = createStrategy(currentTime = "2025-01-15T09:59:59Z")
-
-                // When
-                val result = strategy.evaluate(
-                    featureId = "test",
-                    store = InMemoryFeatureStore(),
-                    context = FlippingExecutionContext(),
-                )
-
-                // Then
-                result.shouldBeFalse()
-            }
-
-            test("returns false when current hour is after endHour") {
-                // Given - 15:00 UTC
-                val strategy = createStrategy(currentTime = "2025-01-15T15:00:00Z")
-
-                // When
-                val result = strategy.evaluate(
-                    featureId = "test",
-                    store = InMemoryFeatureStore(),
-                    context = FlippingExecutionContext(),
-                )
-
-                // Then
-                result.shouldBeFalse()
+                result shouldBe shouldBeEnabled
             }
         }
 
@@ -130,45 +84,20 @@ internal class DailyHoursStrategyTest :
         }
 
         context("validation") {
-            test("throws IllegalArgumentException when startHour is negative") {
-                shouldThrow<IllegalArgumentException> {
-                    DailyHoursStrategy(startHour = -1, endHour = 10)
-                }
-            }
-
-            test("throws IllegalArgumentException when startHour is greater than 23") {
-                shouldThrow<IllegalArgumentException> {
-                    DailyHoursStrategy(startHour = 24, endHour = 25)
-                }
-            }
-
-            test("throws IllegalArgumentException when endHour is negative") {
-                shouldThrow<IllegalArgumentException> {
-                    DailyHoursStrategy(startHour = 0, endHour = -1)
-                }
-            }
-
-            test("throws IllegalArgumentException when endHour is zero") {
-                shouldThrow<IllegalArgumentException> {
-                    DailyHoursStrategy(startHour = 0, endHour = 0)
-                }
-            }
-
-            test("throws IllegalArgumentException when endHour is greater than 24") {
-                shouldThrow<IllegalArgumentException> {
-                    DailyHoursStrategy(startHour = 10, endHour = 25)
-                }
-            }
-
-            test("throws IllegalArgumentException when endHour equals startHour") {
-                shouldThrow<IllegalArgumentException> {
-                    DailyHoursStrategy(startHour = 10, endHour = 10)
-                }
-            }
-
-            test("throws IllegalArgumentException when endHour is before startHour") {
-                shouldThrow<IllegalArgumentException> {
-                    DailyHoursStrategy(startHour = 14, endHour = 10)
+            context("throws IllegalArgumentException for invalid configuration") {
+                withData(
+                    nameFn = { "start: ${it.start}, end: ${it.end}" },
+                    InvalidDailyHoursTestCase(-1, 10), // start negative
+                    InvalidDailyHoursTestCase(24, 25), // start > 23
+                    InvalidDailyHoursTestCase(0, -1), // end negative
+                    InvalidDailyHoursTestCase(0, 0), // end zero
+                    InvalidDailyHoursTestCase(10, 25), // end > 24
+                    InvalidDailyHoursTestCase(10, 10), // start == end
+                    InvalidDailyHoursTestCase(14, 10), // start > end
+                ) { (start, end) ->
+                    shouldThrow<IllegalArgumentException> {
+                        DailyHoursStrategy(startHour = start, endHour = end)
+                    }
                 }
             }
 
@@ -226,3 +155,7 @@ private fun createStrategy(
     timezone = timeZone,
     clock = fixedClock(Instant.parse(currentTime)),
 )
+
+private data class DailyHoursEvaluationTestCase(val currentTime: String, val shouldBeEnabled: Boolean)
+
+private data class InvalidDailyHoursTestCase(val start: Int, val end: Int)

--- a/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/strategy/DateRangeStrategyTest.kt
+++ b/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/strategy/DateRangeStrategyTest.kt
@@ -5,8 +5,8 @@ import com.yonatankarp.ff4k.core.FlippingStrategy
 import com.yonatankarp.ff4k.store.InMemoryFeatureStore
 import com.yonatankarp.ff4k.test.contract.strategy.FlippingStrategyContractTest
 import com.yonatankarp.ff4k.utils.fixedClock
-import io.kotest.matchers.booleans.shouldBeFalse
-import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.datatest.withData
+import io.kotest.matchers.shouldBe
 import kotlinx.datetime.Instant
 import kotlin.time.Duration.Companion.days
 import kotlin.time.Duration.Companion.milliseconds
@@ -27,12 +27,20 @@ internal class DateRangeStrategyTest :
                 }
             }
 
-            test("returns true when now equals startDate (inclusive)") {
+            withData(
+                nameFn = { "current: ${it.currentDate} -> expect: ${it.shouldBeEnabled}" },
+                DateRangeTestCase(startDate, true),
+                DateRangeTestCase(endDate, false),
+                DateRangeTestCase(startDate.plus(1.milliseconds), true),
+                DateRangeTestCase(endDate.minus(1.milliseconds), true),
+                DateRangeTestCase(startDate.minus(1.milliseconds), false),
+                DateRangeTestCase(endDate.plus(1.milliseconds), false),
+            ) { (currentDate, shouldBeEnabled) ->
                 // Given
                 val strategy = DateRangeStrategy(
                     startDate = startDate,
                     endDate = endDate,
-                    clock = fixedClock(startDate),
+                    clock = fixedClock(currentDate),
                 )
                 val store = InMemoryFeatureStore()
                 val context = FlippingExecutionContext()
@@ -41,92 +49,7 @@ internal class DateRangeStrategyTest :
                 val result = strategy.evaluate("test", store, context)
 
                 // Then
-                result.shouldBeTrue()
-            }
-
-            test("returns false when now equals endDate (exclusive)") {
-                // Given
-                val strategy = DateRangeStrategy(
-                    startDate = startDate,
-                    endDate = endDate,
-                    clock = fixedClock(endDate),
-                )
-                val store = InMemoryFeatureStore()
-                val context = FlippingExecutionContext()
-
-                // When
-                val result = strategy.evaluate("test", store, context)
-
-                // Then
-                result.shouldBeFalse()
-            }
-
-            test("returns true when now is 1ms after startDate") {
-                // Given
-                val strategy = DateRangeStrategy(
-                    startDate = startDate,
-                    endDate = endDate,
-                    clock = fixedClock(startDate.plus(1.milliseconds)),
-                )
-                val store = InMemoryFeatureStore()
-                val context = FlippingExecutionContext()
-
-                // When
-                val result = strategy.evaluate("test", store, context)
-
-                // Then
-                result.shouldBeTrue()
-            }
-
-            test("returns true when now is 1ms before endDate") {
-                // Given
-                val strategy = DateRangeStrategy(
-                    startDate = startDate,
-                    endDate = endDate,
-                    clock = fixedClock(endDate.minus(1.milliseconds)),
-                )
-                val store = InMemoryFeatureStore()
-                val context = FlippingExecutionContext()
-
-                // When
-                val result = strategy.evaluate("test", store, context)
-
-                // Then
-                result.shouldBeTrue()
-            }
-
-            test("returns false when now is 1ms before startDate") {
-                // Given
-                val strategy = DateRangeStrategy(
-                    startDate = startDate,
-                    endDate = endDate,
-                    clock = fixedClock(startDate.minus(1.milliseconds)),
-                )
-                val store = InMemoryFeatureStore()
-                val context = FlippingExecutionContext()
-
-                // When
-                val result = strategy.evaluate("test", store, context)
-
-                // Then
-                result.shouldBeFalse()
-            }
-
-            test("returns false when now is 1ms after endDate") {
-                // Given
-                val strategy = DateRangeStrategy(
-                    startDate = startDate,
-                    endDate = endDate,
-                    clock = fixedClock(endDate.plus(1.milliseconds)),
-                )
-                val store = InMemoryFeatureStore()
-                val context = FlippingExecutionContext()
-
-                // When
-                val result = strategy.evaluate("test", store, context)
-
-                // Then
-                result.shouldBeFalse()
+                result shouldBe shouldBeEnabled
             }
         }
     }) {
@@ -153,3 +76,5 @@ internal class DateRangeStrategyTest :
     override fun expectedJsonForSampleParams(): String = // language=json
         """{"type":"dateRange","startDate":"2025-01-01T00:00:00Z","endDate":"2025-01-30T00:00:00Z"}"""
 }
+
+private data class DateRangeTestCase(val currentDate: Instant, val shouldBeEnabled: Boolean)

--- a/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/strategy/DenyListStrategyTest.kt
+++ b/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/strategy/DenyListStrategyTest.kt
@@ -6,7 +6,7 @@ import com.yonatankarp.ff4k.core.FlippingStrategy
 import com.yonatankarp.ff4k.serialization.FF4kJson
 import com.yonatankarp.ff4k.store.InMemoryFeatureStore
 import com.yonatankarp.ff4k.test.contract.strategy.FlippingStrategyContractTest
-import io.kotest.matchers.booleans.shouldBeFalse
+import io.kotest.datatest.withData
 import io.kotest.matchers.booleans.shouldBeTrue
 import io.kotest.matchers.shouldBe
 import kotlinx.serialization.encodeToString
@@ -41,16 +41,27 @@ internal class DenyListStrategyTest :
                 result.shouldBeTrue()
             }
 
-            test("returns false only for users in the deny list") {
-                // Given
-                val strategy = DenyListStrategy(setOf("Alice", "Charlie"))
-                val store = InMemoryFeatureStore()
+            context("returns false only for users in the deny list") {
+                withData(
+                    DenyListTestCase("Alice", false),
+                    DenyListTestCase("Charlie", false),
+                    DenyListTestCase("Bob", true),
+                    DenyListTestCase("David", true),
+                ) { (user, shouldBeAllowed) ->
+                    // Given
+                    val strategy = DenyListStrategy(setOf("Alice", "Charlie"))
+                    val store = InMemoryFeatureStore()
 
-                // When / Then
-                strategy.evaluate("test", store, FlippingExecutionContext(ContextKeys.USER_ID to "Alice")).shouldBeFalse()
-                strategy.evaluate("test", store, FlippingExecutionContext(ContextKeys.USER_ID to "Charlie")).shouldBeFalse()
-                strategy.evaluate("test", store, FlippingExecutionContext(ContextKeys.USER_ID to "Bob")).shouldBeTrue()
-                strategy.evaluate("test", store, FlippingExecutionContext(ContextKeys.USER_ID to "David")).shouldBeTrue()
+                    // When
+                    val result = strategy.evaluate(
+                        "test",
+                        store,
+                        FlippingExecutionContext(ContextKeys.USER_ID to user),
+                    )
+
+                    // Then
+                    result shouldBe shouldBeAllowed
+                }
             }
 
             test("handles null feature store") {
@@ -104,3 +115,5 @@ internal class DenyListStrategyTest :
     override fun expectedJsonForSampleParams(): String = // language=json
         """{"type":"denyList","denyList":["Alice"]}"""
 }
+
+private data class DenyListTestCase(val user: String, val shouldBeAllowed: Boolean)

--- a/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/strategy/PonderationStrategyTest.kt
+++ b/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/strategy/PonderationStrategyTest.kt
@@ -5,6 +5,7 @@ import com.yonatankarp.ff4k.core.FlippingStrategy
 import com.yonatankarp.ff4k.store.InMemoryFeatureStore
 import com.yonatankarp.ff4k.test.contract.strategy.FlippingStrategyContractTest
 import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.datatest.withData
 import io.kotest.matchers.booleans.shouldBeTrue
 import io.kotest.matchers.doubles.shouldBeBetween
 import io.kotest.matchers.shouldBe
@@ -32,15 +33,16 @@ internal class PonderationStrategyTest :
         }
 
         context("Int constructor") {
-            test("converts percentage to weight correctly") {
-                PonderationStrategy(50).weight shouldBe 0.5
-                PonderationStrategy(25).weight shouldBe 0.25
-                PonderationStrategy(75).weight shouldBe 0.75
-            }
-
-            test("handles edge cases") {
-                PonderationStrategy(0).weight shouldBe 0.0
-                PonderationStrategy(100).weight shouldBe 1.0
+            context("converts percentage to weight correctly") {
+                withData(
+                    PercentageToWeightTestCase(50, 0.5),
+                    PercentageToWeightTestCase(25, 0.25),
+                    PercentageToWeightTestCase(75, 0.75),
+                    PercentageToWeightTestCase(0, 0.0),
+                    PercentageToWeightTestCase(100, 1.0),
+                ) { (percentage, expectedWeight) ->
+                    PonderationStrategy(percentage).weight shouldBe expectedWeight
+                }
             }
 
             test("evaluates correctly with percentage constructor") {
@@ -57,27 +59,31 @@ internal class PonderationStrategyTest :
         }
 
         context("validation") {
-            test("throws IllegalArgumentException when weight is negative") {
-                shouldThrow<IllegalArgumentException> {
-                    PonderationStrategy(-0.1)
+            context("throws IllegalArgumentException for invalid weight") {
+                withData(
+                    nameFn = { "weight: $it" },
+                    -0.1,
+                    1.1,
+                    -1.0,
+                    2.0,
+                ) { weight ->
+                    shouldThrow<IllegalArgumentException> {
+                        PonderationStrategy(weight)
+                    }
                 }
             }
 
-            test("throws IllegalArgumentException when weight is greater than 1.0") {
-                shouldThrow<IllegalArgumentException> {
-                    PonderationStrategy(1.1)
-                }
-            }
-
-            test("throws IllegalArgumentException when percentage is negative") {
-                shouldThrow<IllegalArgumentException> {
-                    PonderationStrategy(-1)
-                }
-            }
-
-            test("throws IllegalArgumentException when percentage is greater than 100") {
-                shouldThrow<IllegalArgumentException> {
-                    PonderationStrategy(101)
+            context("throws IllegalArgumentException for invalid percentage") {
+                withData(
+                    nameFn = { "percentage: $it" },
+                    -1,
+                    101,
+                    -50,
+                    150,
+                ) { percentage ->
+                    shouldThrow<IllegalArgumentException> {
+                        PonderationStrategy(percentage)
+                    }
                 }
             }
         }
@@ -94,3 +100,5 @@ internal class PonderationStrategyTest :
     override fun expectedJsonForSampleParams(): String = // language=json
         """{"type":"ponderation","weight":1.0}"""
 }
+
+private data class PercentageToWeightTestCase(val percentage: Int, val expectedWeight: Double)

--- a/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/strategy/ReleaseDateStrategyTest.kt
+++ b/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/strategy/ReleaseDateStrategyTest.kt
@@ -5,6 +5,7 @@ import com.yonatankarp.ff4k.core.FlippingStrategy
 import com.yonatankarp.ff4k.store.InMemoryFeatureStore
 import com.yonatankarp.ff4k.test.contract.strategy.FlippingStrategyContractTest
 import com.yonatankarp.ff4k.utils.fixedClock
+import io.kotest.datatest.withData
 import io.kotest.matchers.booleans.shouldBeFalse
 import io.kotest.matchers.booleans.shouldBeTrue
 import kotlinx.datetime.Instant
@@ -16,11 +17,18 @@ internal class ReleaseDateStrategyTest :
         val releaseDate = Instant.parse("2025-12-08T00:00:00.000Z")
 
         context("evaluate boundary conditions") {
-            test("returns true when now equals releaseDate (inclusive)") {
+            withData(
+                nameFn = { "current: ${it.currentDate} -> expect: ${it.shouldBeEnabled}" },
+                ReleaseDateTestCase(releaseDate, true),
+                ReleaseDateTestCase(releaseDate.plus(1.milliseconds), true),
+                ReleaseDateTestCase(releaseDate.minus(1.milliseconds), false),
+                ReleaseDateTestCase(Instant.parse("2099-01-01T00:00:00.000Z"), true),
+                ReleaseDateTestCase(Instant.parse("2000-01-01T00:00:00.000Z"), false),
+            ) { (currentDate, shouldBeEnabled) ->
                 // Given
                 val strategy = ReleaseDateStrategy(
                     releaseDate = releaseDate,
-                    clock = fixedClock(releaseDate),
+                    clock = fixedClock(currentDate),
                 )
                 val store = InMemoryFeatureStore()
                 val context = FlippingExecutionContext()
@@ -29,73 +37,11 @@ internal class ReleaseDateStrategyTest :
                 val result = strategy.evaluate("test", store, context)
 
                 // Then
-                result.shouldBeTrue()
-            }
-
-            test("returns true when now is 1ms after releaseDate") {
-                // Given
-                val strategy = ReleaseDateStrategy(
-                    releaseDate = releaseDate,
-                    clock = fixedClock(releaseDate.plus(1.milliseconds)),
-                )
-                val store = InMemoryFeatureStore()
-                val context = FlippingExecutionContext()
-
-                // When
-                val result = strategy.evaluate("test", store, context)
-
-                // Then
-                result.shouldBeTrue()
-            }
-
-            test("returns false when now is 1ms before releaseDate") {
-                // Given
-                val strategy = ReleaseDateStrategy(
-                    releaseDate = releaseDate,
-                    clock = fixedClock(releaseDate.minus(1.milliseconds)),
-                )
-                val store = InMemoryFeatureStore()
-                val context = FlippingExecutionContext()
-
-                // When
-                val result = strategy.evaluate("test", store, context)
-
-                // Then
-                result.shouldBeFalse()
-            }
-
-            test("returns true when now is far in the future") {
-                // Given
-                val farFuture = Instant.parse("2099-01-01T00:00:00.000Z")
-                val strategy = ReleaseDateStrategy(
-                    releaseDate = releaseDate,
-                    clock = fixedClock(farFuture),
-                )
-                val store = InMemoryFeatureStore()
-                val context = FlippingExecutionContext()
-
-                // When
-                val result = strategy.evaluate("test", store, context)
-
-                // Then
-                result.shouldBeTrue()
-            }
-
-            test("returns false when now is far in the past") {
-                // Given
-                val farPast = Instant.parse("2000-01-01T00:00:00.000Z")
-                val strategy = ReleaseDateStrategy(
-                    releaseDate = releaseDate,
-                    clock = fixedClock(farPast),
-                )
-                val store = InMemoryFeatureStore()
-                val context = FlippingExecutionContext()
-
-                // When
-                val result = strategy.evaluate("test", store, context)
-
-                // Then
-                result.shouldBeFalse()
+                if (shouldBeEnabled) {
+                    result.shouldBeTrue()
+                } else {
+                    result.shouldBeFalse()
+                }
             }
         }
     }) {
@@ -119,3 +65,5 @@ internal class ReleaseDateStrategyTest :
     override fun expectedJsonForSampleParams(): String = // language=json
         """{"type":"releaseDate","releaseDate":"2025-12-08T00:00:00Z"}"""
 }
+
+private data class ReleaseDateTestCase(val currentDate: Instant, val shouldBeEnabled: Boolean)

--- a/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/strategy/UserPonderationStrategyTest.kt
+++ b/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/strategy/UserPonderationStrategyTest.kt
@@ -6,6 +6,7 @@ import com.yonatankarp.ff4k.core.FlippingStrategy
 import com.yonatankarp.ff4k.store.InMemoryFeatureStore
 import com.yonatankarp.ff4k.test.contract.strategy.FlippingStrategyContractTest
 import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.datatest.withData
 import io.kotest.matchers.booleans.shouldBeFalse
 import io.kotest.matchers.booleans.shouldBeTrue
 import io.kotest.matchers.doubles.shouldBeBetween
@@ -76,15 +77,16 @@ internal class UserPonderationStrategyTest :
         }
 
         context("Int constructor") {
-            test("converts percentage to weight correctly") {
-                UserPonderationStrategy(50).weight shouldBe 0.5
-                UserPonderationStrategy(25).weight shouldBe 0.25
-                UserPonderationStrategy(75).weight shouldBe 0.75
-            }
-
-            test("handles edge cases") {
-                UserPonderationStrategy(0).weight shouldBe 0.0
-                UserPonderationStrategy(100).weight shouldBe 1.0
+            context("converts percentage to weight correctly") {
+                withData(
+                    UserPercentageToWeightTestCase(50, 0.5),
+                    UserPercentageToWeightTestCase(25, 0.25),
+                    UserPercentageToWeightTestCase(75, 0.75),
+                    UserPercentageToWeightTestCase(0, 0.0),
+                    UserPercentageToWeightTestCase(100, 1.0),
+                ) { (percentage, expectedWeight) ->
+                    UserPonderationStrategy(percentage).weight shouldBe expectedWeight
+                }
             }
 
             test("evaluates correctly with percentage constructor") {
@@ -101,27 +103,31 @@ internal class UserPonderationStrategyTest :
         }
 
         context("validation") {
-            test("throws IllegalArgumentException when weight is negative") {
-                shouldThrow<IllegalArgumentException> {
-                    UserPonderationStrategy(-0.1)
+            context("throws IllegalArgumentException for invalid weight") {
+                withData(
+                    nameFn = { "weight: $it" },
+                    -0.1,
+                    1.1,
+                    -1.0,
+                    2.0,
+                ) { weight ->
+                    shouldThrow<IllegalArgumentException> {
+                        UserPonderationStrategy(weight)
+                    }
                 }
             }
 
-            test("throws IllegalArgumentException when weight is greater than 1.0") {
-                shouldThrow<IllegalArgumentException> {
-                    UserPonderationStrategy(1.1)
-                }
-            }
-
-            test("throws IllegalArgumentException when percentage is negative") {
-                shouldThrow<IllegalArgumentException> {
-                    UserPonderationStrategy(-1)
-                }
-            }
-
-            test("throws IllegalArgumentException when percentage is greater than 100") {
-                shouldThrow<IllegalArgumentException> {
-                    UserPonderationStrategy(101)
+            context("throws IllegalArgumentException for invalid percentage") {
+                withData(
+                    nameFn = { "percentage: $it" },
+                    -1,
+                    101,
+                    -50,
+                    150,
+                ) { percentage ->
+                    shouldThrow<IllegalArgumentException> {
+                        UserPonderationStrategy(percentage)
+                    }
                 }
             }
         }
@@ -140,3 +146,5 @@ internal class UserPonderationStrategyTest :
 
     override fun requiredContextKeys(): Set<String> = setOf(ContextKeys.USER_ID)
 }
+
+private data class UserPercentageToWeightTestCase(val percentage: Int, val expectedWeight: Double)

--- a/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/strategy/WeekdayStrategyTest.kt
+++ b/ff4k-core/src/commonTest/kotlin/com/yonatankarp/ff4k/strategy/WeekdayStrategyTest.kt
@@ -5,8 +5,10 @@ import com.yonatankarp.ff4k.core.FlippingStrategy
 import com.yonatankarp.ff4k.store.InMemoryFeatureStore
 import com.yonatankarp.ff4k.test.contract.strategy.FlippingStrategyContractTest
 import com.yonatankarp.ff4k.utils.fixedClock
+import io.kotest.datatest.withData
 import io.kotest.matchers.booleans.shouldBeFalse
 import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.shouldBe
 import kotlinx.datetime.DayOfWeek
 import kotlinx.datetime.Instant
 import kotlinx.datetime.TimeZone
@@ -24,83 +26,55 @@ internal class WeekdayStrategyTest :
         // 2025-01-19 = Sunday
 
         context("evaluate with allowed days") {
-            test("returns true when current day is in allowedDays") {
-                // Given - Monday
-                val strategy = createStrategy(currentTime = "2025-01-13T12:00:00Z")
-
-                // When
-                val result = strategy.evaluate(
-                    featureId = "test",
-                    store = InMemoryFeatureStore(),
-                    context = FlippingExecutionContext(),
-                )
-
-                // Then
-                result.shouldBeTrue()
-            }
-
-            test("returns false when current day is not in allowedDays") {
-                // Given - Tuesday (not in allowed days)
-                val strategy = createStrategy(currentTime = "2025-01-14T12:00:00Z")
-
-                // When
-                val result = strategy.evaluate(
-                    featureId = "test",
-                    store = InMemoryFeatureStore(),
-                    context = FlippingExecutionContext(),
-                )
-
-                // Then
-                result.shouldBeFalse()
-            }
-
-            test("returns true for weekend day when weekends are allowed") {
-                // Given - Saturday
-                val strategy = createStrategy(
-                    allowedDays = setOf(DayOfWeek.SATURDAY, DayOfWeek.SUNDAY),
-                    currentTime = "2025-01-18T12:00:00Z",
-                )
-
-                // When
-                val result = strategy.evaluate(
-                    featureId = "test",
-                    store = InMemoryFeatureStore(),
-                    context = FlippingExecutionContext(),
-                )
-
-                // Then
-                result.shouldBeTrue()
-            }
-
-            test("returns false for weekend day when only weekdays are allowed") {
-                // Given - Sunday
-                val strategy = createStrategy(
-                    allowedDays = setOf(
+            withData(
+                nameFn = { "current: ${it.currentTime}, allowed: ${it.allowedDays} -> expect: ${it.shouldBeEnabled}" },
+                // Monday allowed, Current Monday
+                WeekdayTestCase(
+                    "2025-01-13T12:00:00Z",
+                    setOf(DayOfWeek.MONDAY, DayOfWeek.WEDNESDAY, DayOfWeek.FRIDAY),
+                    true,
+                ),
+                // Monday allowed, Current Tuesday
+                WeekdayTestCase(
+                    "2025-01-14T12:00:00Z",
+                    setOf(DayOfWeek.MONDAY, DayOfWeek.WEDNESDAY, DayOfWeek.FRIDAY),
+                    false,
+                ),
+                // Weekend allowed, Current Saturday
+                WeekdayTestCase(
+                    "2025-01-18T12:00:00Z",
+                    setOf(DayOfWeek.SATURDAY, DayOfWeek.SUNDAY),
+                    true,
+                ),
+                // Weekdays allowed, Current Sunday
+                WeekdayTestCase(
+                    "2025-01-19T12:00:00Z",
+                    setOf(
                         DayOfWeek.MONDAY,
                         DayOfWeek.TUESDAY,
                         DayOfWeek.WEDNESDAY,
                         DayOfWeek.THURSDAY,
                         DayOfWeek.FRIDAY,
                     ),
-                    currentTime = "2025-01-19T12:00:00Z",
-                )
-
-                // When
-                val result = strategy.evaluate(
-                    featureId = "test",
-                    store = InMemoryFeatureStore(),
-                    context = FlippingExecutionContext(),
-                )
-
-                // Then
-                result.shouldBeFalse()
-            }
-
-            test("returns false when allowedDays is empty") {
-                // Given - any day with empty allowedDays
+                    false,
+                ),
+                // Empty allowed days
+                WeekdayTestCase(
+                    "2025-01-15T12:00:00Z",
+                    emptySet(),
+                    false,
+                ),
+                // All days allowed
+                WeekdayTestCase(
+                    "2025-01-15T12:00:00Z",
+                    DayOfWeek.entries.toSet(),
+                    true,
+                ),
+            ) { (currentTime, allowedDays, shouldBeEnabled) ->
+                // Given
                 val strategy = createStrategy(
-                    allowedDays = emptySet(),
-                    currentTime = "2025-01-15T12:00:00Z",
+                    allowedDays = allowedDays,
+                    currentTime = currentTime,
                 )
 
                 // When
@@ -111,25 +85,7 @@ internal class WeekdayStrategyTest :
                 )
 
                 // Then
-                result.shouldBeFalse()
-            }
-
-            test("returns true when all days are allowed") {
-                // Given - any day with all days allowed
-                val strategy = createStrategy(
-                    allowedDays = DayOfWeek.entries.toSet(),
-                    currentTime = "2025-01-15T12:00:00Z",
-                )
-
-                // When
-                val result = strategy.evaluate(
-                    featureId = "test",
-                    store = InMemoryFeatureStore(),
-                    context = FlippingExecutionContext(),
-                )
-
-                // Then
-                result.shouldBeTrue()
+                result shouldBe shouldBeEnabled
             }
         }
 
@@ -202,4 +158,10 @@ private fun createStrategy(
     allowedDays = allowedDays,
     timezone = timezone,
     clock = fixedClock(Instant.parse(currentTime)),
+)
+
+private data class WeekdayTestCase(
+    val currentTime: String,
+    val allowedDays: Set<DayOfWeek>,
+    val shouldBeEnabled: Boolean,
 )


### PR DESCRIPTION
## Summary

Refactored various `FlippingStrategy` tests in `ff4k-core` to use Kotest's data-driven testing (`withData`). This reduces boilerplate code and improves the readability and maintainability of the test suite.

## Motivation

The existing tests contained significant code duplication for similar test cases, such as checking multiple users against a list or verifying boundary conditions. Adopting parameterized tests makes these scenarios cleaner, easier to read, and simpler to extend in the future.


## Changes

<!-- What does this PR do? List the main changes -->

   - Refactored AllowListStrategyTest and DenyListStrategyTest to use withData for list checks.
   - Refactored PonderationStrategyTest and UserPonderationStrategyTest to parameterize percentage-to-weight conversion and validation logic.
   - Refactored WeekdayStrategyTest to use data-driven tests for allowed days evaluation.
   - Refactored ReleaseDateStrategyTest, DateRangeStrategyTest, and DailyHoursStrategyTest to parameterize boundary condition checks.


## Testing

<!-- How did you test these changes? -->

   - [x] Unit tests added/updated
   - [x] Tested on JVM
   - [ ] Tested on Android
   - [ ] Tested on iOS

## Checklist

   - [x] My code follows the project's code style (./gradlew spotlessCheck passes)
   - [x] I have added tests that prove my fix/feature works
   - [x] All tests pass (./gradlew check)
   - [ ] I have updated documentation if needed
   - [ ] I marked all checkboxes without reading
