### PR TITLE
fix(ci): trigger docs update after release and restore 'v' prefix

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -5,12 +5,21 @@ on:
     branches:
       - main
   workflow_dispatch:
+  workflow_run:
+    workflows: ["Publish Release"]
+    types:
+      - completed
 
 permissions:
   contents: write
 
+concurrency:
+  group: documentation
+  cancel-in-progress: false
+
 jobs:
   deploy:
+    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -84,6 +84,7 @@ jobs:
       contents: write
     outputs:
       version: ${{ steps.version.outputs.VERSION }}
+      tag_name: ${{ steps.version.outputs.TAG_NAME }}
 
     steps:
       - name: Checkout code
@@ -112,7 +113,9 @@ jobs:
 
       - name: Extract version from tag
         id: version
-        run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
+        run: |
+          echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
+          echo "TAG_NAME=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
 
       - name: Publish to Maven Central
         run: ./gradlew publishAllPublicationsToMavenCentralRepository "-Pversion=${{ steps.version.outputs.VERSION }}" --parallel --no-daemon
@@ -141,6 +144,9 @@ jobs:
   deploy-docs:
     needs: publish
     runs-on: ubuntu-latest
+    concurrency:
+      group: documentation
+      cancel-in-progress: false
     permissions:
       contents: write
 
@@ -153,6 +159,6 @@ jobs:
       - name: Deploy release docs
         uses: ./.github/actions/deploy-docs
         with:
-          version: ${{ needs.publish.outputs.version }}
+          version: ${{ needs.publish.outputs.tag_name }}
           aliases: latest
           gradle-version-arg: "-Pversion=${{ needs.publish.outputs.version }}"


### PR DESCRIPTION
## Summary

<!-- Brief description of the changes (1-3 sentences) -->

Fixes the documentation deployment workflow to ensure the snapshot version is updated immediately after a release and restores the v prefix for versioned documentation.

## Motivation

<!-- Why is this change needed? Link to related issue if applicable -->

After the `0.2.0` release, the documentation site failed to update the main (snapshot) version to 0.3.0-SNAPSHOT because the documentation workflow was not triggered by the tag push. Additionally, the release documentation was deployed as `0.2.0` instead of `v0.2.0`, breaking consistency with previous versions.

## Changes

<!-- What does this PR do? List the main changes -->

   - `.github/workflows/documentation.yml`: Added a workflow_run trigger to execute the documentation build automatically when the "Publish Release" workflow completes successfully. Added concurrency control.
   - `.github/workflows/publish-release.yml`:
       - Updated the publish job to output both the standard version (e.g., 0.2.0) for Gradle and the tag name (e.g., v0.2.0) for documentation.
       - Configured the deploy-docs job to use the tag name for mike deploy.
       - Added concurrency control to prevent deployment race conditions.


## Testing

<!-- How did you test these changes? -->

- [ ] Unit tests added/updated
- [ ] Tested on JVM
- [ ] Tested on Android
- [ ] Tested on iOS

## Checklist

- [ ] My code follows the project's code style (`./gradlew spotlessCheck` passes)
- [ ] I have added tests that prove my fix/feature works
- [ ] All tests pass (`./gradlew check`)
- [ ] I have updated documentation if needed
- [ ] I marked all checkboxes without reading


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved coordination between release publishing and documentation deployment workflows.
  * Enhanced concurrency handling to prevent simultaneous documentation deployments.
  * Ensured version information is properly passed through the release pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->