### PR TITLE
fix(docs): use version-specific git refs in Dokka source links

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,7 @@ CLAUDE.md
 
 .DS_Store
 .aider*
+
+### Docs
+.venv
+site/**

--- a/build-logic/src/main/kotlin/ff4k.documentation.gradle.kts
+++ b/build-logic/src/main/kotlin/ff4k.documentation.gradle.kts
@@ -7,11 +7,17 @@ plugins {
 configure<DokkaExtension> {
     moduleName.set(project.name)
 
+    val version = project.version.toString()
+    val gitReference = when {
+        version.endsWith("-SNAPSHOT") -> "main"
+        else -> "v$version"
+    }
+
     dokkaSourceSets.configureEach {
         sourceLink {
             localDirectory.set(projectDir.resolve("src"))
             remoteUrl.set(
-                uri("https://github.com/yonatankarp/ff4k/tree/main/${project.name}/src")
+                uri("https://github.com/yonatankarp/ff4k/tree/$gitReference/${project.name}/src")
             )
             remoteLineSuffix.set("#L")
         }


### PR DESCRIPTION
## Summary

Dokka source links were hardcoded to the `main` branch, causing "View Source" links in all versioned API docs to point to `main` regardless of the actual release version. This fix makes the git ref dynamic based on `project.version`.

## Motivation

When viewing the API docs e.g., `v0.1.3`, clicking "source" would navigate to https://github.com/yonatankarp/ff4k/tree/main/... instead of https://github.com/yonatankarp/ff4k/tree/v0.1.3/.... This could show incorrect or newer code that doesn't match the version being documented.  

## Changes

<!-- What does this PR do? List the main changes -->

  - Updated build-logic/src/main/kotlin/ff4k.documentation.gradle.kts to derive the git ref from `project.version`: SNAPSHOT versions link to main, release versions link to vX.Y.Z    
  - Backfilled all existing versioned docs on gh-pages (v0.1.0–v0.2.0) with corrected source links, the `mike` version switcher bar, and version-local API Reference nav links         
        

## Testing

<!-- How did you test these changes? -->

- [ ] Unit tests added/updated
- [ ] Tested on JVM
- [ ] Tested on Android
- [ ] Tested on iOS

## Checklist

- [ ] My code follows the project's code style (`./gradlew spotlessCheck` passes)
- [ ] I have added tests that prove my fix/feature works
- [ ] All tests pass (`./gradlew check`)
- [ ] I have updated documentation if needed
- [ ] I marked all checkboxes without reading


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project ignore patterns to include documentation-related directories
  * Modified documentation build configuration to dynamically reference source code based on release version

<!-- end of auto-generated comment: release notes by coderabbit.ai -->