### PR TITLE
refactor(build-logic): extract platform detection into shared utilities

### DIFF
--- a/build-logic/src/main/kotlin/com/yonatankarp/ff4k/buildlogic/PlatformAvailability.kt
+++ b/build-logic/src/main/kotlin/com/yonatankarp/ff4k/buildlogic/PlatformAvailability.kt
@@ -1,0 +1,30 @@
+package com.yonatankarp.ff4k.buildlogic
+
+import org.gradle.api.Project
+import java.io.File
+import java.util.Properties
+
+fun Project.isAndroidSdkAvailable(): Boolean {
+    val env = System.getenv("ANDROID_HOME") ?: System.getenv("ANDROID_SDK_ROOT")
+    if (env != null && File(env).exists()) return true
+    val localProperties = rootProject.file("local.properties")
+    if (localProperties.exists()) {
+        val properties = Properties()
+        localProperties.inputStream().use { properties.load(it) }
+        val sdkDir = properties.getProperty("sdk.dir")
+        return sdkDir != null && File(sdkDir).exists()
+    }
+    return false
+}
+
+fun Project.areAppleTargetsAvailable(): Boolean {
+    val localProperties = rootProject.file("local.properties")
+    if (localProperties.exists()) {
+        val properties = Properties()
+        localProperties.inputStream().use { properties.load(it) }
+        if (properties.getProperty("ff4k.include.apple") == "false") return false
+    }
+    val osName = System.getProperty("os.name")
+    if (!osName.contains("Mac", ignoreCase = true)) return false
+    return File("/usr/bin/xcrun").exists()
+}

--- a/build-logic/src/main/kotlin/ff4k.android.gradle.kts
+++ b/build-logic/src/main/kotlin/ff4k.android.gradle.kts
@@ -1,24 +1,10 @@
-import java.io.File
-import java.util.Properties
 import com.android.build.gradle.LibraryExtension
 import org.gradle.api.JavaVersion
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
+import com.yonatankarp.ff4k.buildlogic.isAndroidSdkAvailable
 
-val androidSdkAvailable: Boolean by lazy {
-    val env = System.getenv("ANDROID_HOME") ?: System.getenv("ANDROID_SDK_ROOT")
-    if (env != null && File(env).exists()) return@lazy true
-    val localProperties = project.rootProject.file("local.properties")
-    if (localProperties.exists()) {
-        val properties = Properties()
-        localProperties.inputStream().use { properties.load(it) }
-        val sdkDir = properties.getProperty("sdk.dir")
-        return@lazy sdkDir != null && File(sdkDir).exists()
-    }
-    false
-}
-
-if (androidSdkAvailable) {
+if (isAndroidSdkAvailable()) {
     apply(plugin = "com.android.library")
 
     configure<KotlinMultiplatformExtension> {

--- a/build-logic/src/main/kotlin/ff4k.ios.gradle.kts
+++ b/build-logic/src/main/kotlin/ff4k.ios.gradle.kts
@@ -1,21 +1,8 @@
-import java.io.File
-import java.util.Properties
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 import org.jetbrains.kotlin.gradle.targets.native.tasks.KotlinNativeTest
+import com.yonatankarp.ff4k.buildlogic.areAppleTargetsAvailable
 
-val appleTargetsAvailable: Boolean by lazy {
-    val localProperties = project.rootProject.file("local.properties")
-    if (localProperties.exists()) {
-        val properties = Properties()
-        localProperties.inputStream().use { properties.load(it) }
-        if (properties.getProperty("ff4k.include.apple") == "false") return@lazy false
-    }
-    val osName = System.getProperty("os.name")
-    if (!osName.contains("Mac", ignoreCase = true)) return@lazy false
-    File("/usr/bin/xcrun").exists()
-}
-
-if (appleTargetsAvailable) {
+if (areAppleTargetsAvailable()) {
     configure<KotlinMultiplatformExtension> {
         iosX64()
         iosArm64()


### PR DESCRIPTION
## Summary

Extract Android SDK and Apple target availability detection logic from individual Gradle scripts into a shared PlatformAvailability.kt utility file for better code reuse and maintainability.

## Motivation

The platform detection logic was duplicated across ff4k.android.gradle.kts and ff4k.ios.gradle.kts. Consolidating this into a single utility file reduces code duplication and makes future maintenance easier

## Changes

<!-- What does this PR do? List the main changes -->

  - Add new PlatformAvailability.kt with isAndroidSdkAvailable() and areAppleTargetsAvailable() extension functions                                                                
  - Refactor ff4k.android.gradle.kts to use the shared isAndroidSdkAvailable() function                                                                                            
  - Refactor ff4k.ios.gradle.kts to use the shared areAppleTargetsAvailable() function  

## Testing

<!-- How did you test these changes? -->

- [x] Unit tests added/updated
- [x] Tested on JVM
- [x] Tested on Android
- [x] Tested on iOS

## Checklist

- [x] My code follows the project's code style (`./gradlew spotlessCheck` passes)
- [ ] I have added tests that prove my fix/feature works
- [x] All tests pass (`./gradlew check`)
- [ ] I have updated documentation if needed
- [ ] I marked all checkboxes without reading


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Extended iOS build configuration to support Simulator on ARM64 architecture for Apple Silicon devices.

* **Chores**
  * Refactored build logic to improve platform availability detection for Android SDK and Apple targets, enabling more flexible conditional compilation based on environment variables, local properties, and system configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->