### PR TITLE
chore(dependabot): ignore major/minor updates for kotlin and sqldelight

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -34,6 +34,8 @@ updates:
       # Kotlin and Android - affects binary compatibility with consumers
       - dependency-name: "org.jetbrains.kotlin:*"
         update-types: ["version-update:semver-major", "version-update:semver-minor"]
+      - dependency-name: "org.jetbrains.kotlin.*"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
       - dependency-name: "com.android.tools.build:gradle"
         update-types: ["version-update:semver-major", "version-update:semver-minor"]
       # Runtime dependencies affecting consumers - only patch updates
@@ -48,4 +50,6 @@ updates:
       - dependency-name: "com.ionspin.kotlin:bignum*"
         update-types: ["version-update:semver-major", "version-update:semver-minor"]
       - dependency-name: "app.cash.sqldelight:*"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
+      - dependency-name: "app.cash.sqldelight"
         update-types: ["version-update:semver-major", "version-update:semver-minor"]


### PR DESCRIPTION
✦ Summary

  This PR updates the Dependabot configuration to ignore major and minor version updates for Kotlin and SQLDelight. It specifically targets both the library artifacts and the
  corresponding Gradle plugins.

  Motivation

  The project needs to maintain compatibility with specific versions of Kotlin (2.0.x) and SQLDelight (2.0.x) and cannot upgrade to newer minor or major versions (e.g., 2.1+ or
  2.2+) at this time. However, we still want to receive patch updates (e.g., 2.0.22) for bug fixes and security improvements. This configuration ensures Dependabot only opens
  PRs for these safe patch updates.

  Changes

- Updated .github/dependabot.yml to ignore version-update:semver-major and version-update:semver-minor for:
- org.jetbrains.kotlin:* (Kotlin libraries)
-  org.jetbrains.kotlin.* (Kotlin plugins)
- app.cash.sqldelight:* (SQLDelight libraries)
- app.cash.sqldelight (SQLDelight plugin)


## Testing

<!-- How did you test these changes? -->

- [ ] Unit tests added/updated
- [ ] Tested on JVM
- [ ] Tested on Android
- [ ] Tested on iOS

## Checklist

- [x] My code follows the project's code style (`./gradlew spotlessCheck` passes)
- [ ] I have added tests that prove my fix/feature works
- [x] All tests pass (`./gradlew check`)
- [ ] I have updated documentation if needed
- [ ] I marked all checkboxes without reading


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Dependabot configuration to enhance dependency tracking and updates for Kotlin and SQLDelight build tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->