### PR TITLE
feat: add PostgreSQL support

### DIFF
--- a/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/exception/FF4kException.kt
+++ b/ff4k-core/src/commonMain/kotlin/com/yonatankarp/ff4k/exception/FF4kException.kt
@@ -16,3 +16,18 @@ package com.yonatankarp.ff4k.exception
  * @see FeatureStoreException Base exception for feature store operations
  */
 sealed class FF4kException(message: String, cause: Throwable? = null) : Exception(message, cause)
+
+/**
+ * Exception for configuration and initialization errors in FF4k.
+ *
+ * This open class is part of the [FF4kException] hierarchy and is intended for
+ * errors that occur during library setup, such as unsupported database types or
+ * invalid configuration. Unlike the sealed store exception hierarchies, this class
+ * is open to allow extension from other modules.
+ *
+ * @param message The detail message describing the exception
+ * @param cause The underlying cause of this exception, or null if none
+ *
+ * @see FF4kException
+ */
+open class FF4kConfigurationException(message: String, cause: Throwable? = null) : FF4kException(message, cause)

--- a/ff4k-store-jdbc/build.gradle.kts
+++ b/ff4k-store-jdbc/build.gradle.kts
@@ -14,10 +14,11 @@ dependencies {
     api(project(":ff4k-core"))
     api(project(":ff4k-store-sql-common"))
 
+    implementation(libs.kotlin.reflect)
     implementation(libs.kotlinx.coroutines.core)
     implementation(libs.kotlinx.serialization.json)
 
-    // Test dependencies
+    testImplementation(project(":ff4k-contract-test"))
     testImplementation(libs.kotest.runner.junit5)
     testImplementation(libs.kotlinx.coroutines.test)
     testImplementation(libs.mockk)

--- a/ff4k-store-jdbc/build.gradle.kts
+++ b/ff4k-store-jdbc/build.gradle.kts
@@ -14,7 +14,6 @@ dependencies {
     api(project(":ff4k-core"))
     api(project(":ff4k-store-sql-common"))
 
-    implementation(libs.kotlin.reflect)
     implementation(libs.kotlinx.coroutines.core)
     implementation(libs.kotlinx.serialization.json)
 
@@ -22,4 +21,8 @@ dependencies {
     testImplementation(libs.kotest.runner.junit5)
     testImplementation(libs.kotlinx.coroutines.test)
     testImplementation(libs.mockk)
+
+    testImplementation(platform(libs.testcontainers.bom))
+    testImplementation(libs.testcontainers.postgresql)
+    testImplementation(libs.postgresql)
 }

--- a/ff4k-store-jdbc/src/main/kotlin/com/yonatankarp/ff4k/store/jdbc/JdbcFeatureStores.kt
+++ b/ff4k-store-jdbc/src/main/kotlin/com/yonatankarp/ff4k/store/jdbc/JdbcFeatureStores.kt
@@ -1,22 +1,26 @@
 package com.yonatankarp.ff4k.store.jdbc
 
 import com.yonatankarp.ff4k.core.FeatureStore
+import com.yonatankarp.ff4k.store.sql.PostgresDialect
 import com.yonatankarp.ff4k.store.sql.SqlDialect
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import kotlinx.serialization.modules.SerializersModule
+import java.util.Locale
 import javax.sql.DataSource
 
+private val SUPPORTED_DATABASES = listOf("PostgreSQL")
+
 /**
- * Creates a JDBC-backed [FeatureStore] with an explicit SQL dialect.
+ * Creates a JDBC-backed [FeatureStore] that auto-detects the database type.
  *
- * Use this factory function to create a feature store that persists features
- * in a relational database via JDBC. The dialect parameter determines the
- * database-specific SQL syntax used for all operations.
+ * The database type is detected using JDBC metadata from the [DataSource].
+ * The feature table is created automatically if it doesn't exist.
  *
  * Example:
  * ```kotlin
- * val store = jdbcFeatureStore(HikariDataSource(config), PostgresDialect)
+ * val store = jdbcFeatureStore(HikariDataSource(config))
  * store += Feature(uid = "my-feature", isEnabled = true)
  * ```
  *
@@ -28,8 +32,28 @@ import javax.sql.DataSource
  *         subclass(MyCustomStrategy::class, MyCustomStrategy.serializer())
  *     }
  * }
- * val store = jdbcFeatureStore(dataSource, PostgresDialect, customModule)
+ * val store = jdbcFeatureStore(dataSource, customModule)
  * ```
+ *
+ * @param dataSource The JDBC [DataSource] for database connections.
+ * @param customSerializersModule Optional serializers for custom types.
+ * @param ioDispatcher The [CoroutineDispatcher] to use for blocking JDBC operations.
+ *   Defaults to [Dispatchers.IO].
+ * @throws UnsupportedDatabaseException If the database type is not supported.
+ */
+suspend fun jdbcFeatureStore(
+    dataSource: DataSource,
+    customSerializersModule: SerializersModule = SerializersModule {},
+    ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
+): FeatureStore {
+    val dialect = withContext(ioDispatcher) { detectDialect(dataSource) }
+    return jdbcFeatureStore(dataSource, dialect, customSerializersModule, ioDispatcher)
+}
+
+/**
+ * Creates a JDBC-backed [FeatureStore] with an explicit SQL dialect.
+ *
+ * Use this when automatic detection doesn't work (e.g., database proxies).
  *
  * @param dataSource The JDBC [DataSource] for database connections.
  * @param dialect The [SqlDialect] for SQL statements.
@@ -43,3 +67,16 @@ suspend fun jdbcFeatureStore(
     customSerializersModule: SerializersModule = SerializersModule {},
     ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
 ): FeatureStore = JdbcFeatureStore(dataSource, dialect, customSerializersModule, ioDispatcher).also { it.ensureSchema() }
+
+private fun detectDialect(dataSource: DataSource): SqlDialect =
+    dataSource.connection.use { conn ->
+        val rawProductName = conn.metaData.databaseProductName
+        val productName = rawProductName.lowercase(Locale.ROOT)
+        when {
+            "postgresql" in productName -> PostgresDialect
+            else -> throw UnsupportedDatabaseException(
+                databaseProductName = rawProductName,
+                supported = SUPPORTED_DATABASES,
+            )
+        }
+    }

--- a/ff4k-store-jdbc/src/main/kotlin/com/yonatankarp/ff4k/store/jdbc/UnsupportedDatabaseException.kt
+++ b/ff4k-store-jdbc/src/main/kotlin/com/yonatankarp/ff4k/store/jdbc/UnsupportedDatabaseException.kt
@@ -1,0 +1,16 @@
+package com.yonatankarp.ff4k.store.jdbc
+
+import com.yonatankarp.ff4k.exception.FF4kConfigurationException
+
+/**
+ * Exception thrown when the database type is not supported.
+ *
+ * @param databaseProductName The name of the unsupported database product.
+ * @param supported A collection of supported database names.
+ */
+class UnsupportedDatabaseException(
+    databaseProductName: String,
+    supported: Collection<String>,
+) : FF4kConfigurationException(
+    "Unsupported database: $databaseProductName. Supported databases: ${supported.joinToString()}",
+)

--- a/ff4k-store-jdbc/src/test/kotlin/com/yonatankarp/ff4k/store/jdbc/JdbcFeatureStoresTest.kt
+++ b/ff4k-store-jdbc/src/test/kotlin/com/yonatankarp/ff4k/store/jdbc/JdbcFeatureStoresTest.kt
@@ -1,0 +1,36 @@
+package com.yonatankarp.ff4k.store.jdbc
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.string.shouldContain
+import io.mockk.every
+import io.mockk.mockk
+import java.sql.Connection
+import java.sql.DatabaseMetaData
+import javax.sql.DataSource
+
+class JdbcFeatureStoresTest : FunSpec({
+
+    test("jdbcFeatureStore throws UnsupportedDatabaseException for unsupported database") {
+        // Given
+        val metadata = mockk<DatabaseMetaData> {
+            every { databaseProductName } returns "Vertica Database"
+        }
+        val connection = mockk<Connection>(relaxed = true) {
+            every { metaData } returns metadata
+        }
+        val dataSource = mockk<DataSource> {
+            every { getConnection() } returns connection
+        }
+
+        // When
+        val exception = shouldThrow<UnsupportedDatabaseException> {
+            jdbcFeatureStore(dataSource)
+        }
+
+        // Then
+        exception.message shouldContain "Vertica Database"
+        exception.message shouldContain "Unsupported database"
+        exception.message shouldContain "PostgreSQL"
+    }
+})

--- a/ff4k-store-jdbc/src/test/kotlin/com/yonatankarp/ff4k/store/jdbc/PostgresFeatureStoreTest.kt
+++ b/ff4k-store-jdbc/src/test/kotlin/com/yonatankarp/ff4k/store/jdbc/PostgresFeatureStoreTest.kt
@@ -1,0 +1,38 @@
+package com.yonatankarp.ff4k.store.jdbc
+
+import com.yonatankarp.ff4k.core.FeatureStore
+import com.yonatankarp.ff4k.test.contract.store.FeatureStoreContractTest
+import kotlinx.coroutines.Dispatchers
+import org.postgresql.ds.PGSimpleDataSource
+import org.testcontainers.postgresql.PostgreSQLContainer
+import javax.sql.DataSource
+
+class PostgresFeatureStoreTest : FeatureStoreContractTest() {
+
+    init {
+        afterSpec {
+            postgres.close()
+        }
+    }
+
+    override suspend fun createStore(): FeatureStore =
+        jdbcFeatureStore(
+            dataSource = postgres.toDataSource(),
+            ioDispatcher = Dispatchers.IO.limitedParallelism(1),
+        ).also { it.clear() }
+
+    companion object {
+        private val postgres: PostgreSQLContainer by lazy {
+            PostgreSQLContainer("postgres:16-alpine").apply {
+                start()
+            }
+        }
+    }
+}
+
+private fun PostgreSQLContainer.toDataSource(): DataSource =
+    PGSimpleDataSource().apply {
+        setUrl(this@toDataSource.jdbcUrl)
+        user = this@toDataSource.username
+        password = this@toDataSource.password
+    }

--- a/ff4k-store-sql-common/src/main/kotlin/com/yonatankarp/ff4k/store/sql/PostgresDialect.kt
+++ b/ff4k-store-sql-common/src/main/kotlin/com/yonatankarp/ff4k/store/sql/PostgresDialect.kt
@@ -1,0 +1,96 @@
+package com.yonatankarp.ff4k.store.sql
+
+import java.sql.SQLException
+
+/**
+ * PostgreSQL-specific SQL dialect for feature store operations.
+ *
+ * Uses:
+ * - TEXT types for string columns
+ * - INTEGER for boolean (0/1) for consistency with other SQL stores
+ * - `ON CONFLICT ... DO UPDATE` for upsert
+ */
+data object PostgresDialect : SqlDialect {
+
+    override val databaseName = "PostgreSQL"
+
+    override val schemaSql: List<String> = listOf(
+        // language=sql
+        """
+            CREATE TABLE IF NOT EXISTS FF4K_FEATURES (
+                uid TEXT PRIMARY KEY NOT NULL,
+                enabled INTEGER NOT NULL DEFAULT 0,
+                group_name TEXT,
+                description TEXT,
+                permissions TEXT NOT NULL DEFAULT '[]',
+                flipping_strategy TEXT,
+                custom_properties TEXT NOT NULL DEFAULT '{}',
+                version INTEGER NOT NULL DEFAULT 1
+            )
+        """.trimIndent(),
+        // language=sql
+        "CREATE INDEX IF NOT EXISTS ff4k_features_enabled_idx ON FF4K_FEATURES (enabled)",
+        // language=sql
+        "CREATE INDEX IF NOT EXISTS ff4k_features_group_name_idx ON FF4K_FEATURES (group_name)",
+    )
+
+    override val selectAllFeaturesSql: String =
+        // language=sql
+        "SELECT uid, enabled, group_name, description, permissions, flipping_strategy, custom_properties, version FROM FF4K_FEATURES"
+
+    override val selectFeatureByUidSql: String =
+        // language=sql
+        "SELECT uid, enabled, group_name, description, permissions, flipping_strategy, custom_properties, version FROM FF4K_FEATURES WHERE uid = ?"
+
+    override val featureExistsSql: String =
+        // language=sql
+        "SELECT EXISTS(SELECT 1 FROM FF4K_FEATURES WHERE uid = ?)"
+
+    override val countFeaturesSql: String =
+        // language=sql
+        "SELECT COUNT(*) FROM FF4K_FEATURES"
+
+    override val insertFeatureSql: String =
+        // language=sql
+        """
+        INSERT INTO FF4K_FEATURES (uid, enabled, group_name, description, permissions, flipping_strategy, custom_properties)
+        VALUES (?, ?, ?, ?, ?, ?, ?)
+        """.trimIndent()
+
+    override val updateFeatureSql: String =
+        // language=sql
+        """
+        UPDATE FF4K_FEATURES
+        SET enabled = ?, group_name = ?, description = ?, permissions = ?, flipping_strategy = ?, custom_properties = ?, version = version + 1
+        WHERE uid = ? AND version = ?
+        """.trimIndent()
+
+    // Note: Uses last-writer-wins semantics without optimistic locking (no version check).
+    // This is intentional for createOrUpdate which doesn't accept an expected version.
+    override val upsertFeatureSql: String =
+        // language=sql
+        """
+        INSERT INTO FF4K_FEATURES (uid, enabled, group_name, description, permissions, flipping_strategy, custom_properties)
+        VALUES (?, ?, ?, ?, ?, ?, ?)
+        ON CONFLICT (uid) DO UPDATE SET
+            enabled = EXCLUDED.enabled,
+            group_name = EXCLUDED.group_name,
+            description = EXCLUDED.description,
+            permissions = EXCLUDED.permissions,
+            flipping_strategy = EXCLUDED.flipping_strategy,
+            custom_properties = EXCLUDED.custom_properties,
+            version = FF4K_FEATURES.version + 1
+        """.trimIndent()
+
+    override val deleteFeatureByUidSql: String =
+        // language=sql
+        "DELETE FROM FF4K_FEATURES WHERE uid = ?"
+
+    override val deleteAllFeaturesSql: String =
+        // language=sql
+        "DELETE FROM FF4K_FEATURES"
+
+    override fun isUniqueConstraintViolation(e: SQLException): Boolean {
+        return "23505" == e.sqlState
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,6 +8,7 @@ kmp-datetime = "0.7.1"
 kotlin = "2.3.10"
 kover = "0.9.7"
 mockk = "1.13.13"
+postgresql = "42.7.7"
 robolectric = "4.16.1"
 serialization = "1.10.0"
 slf4j = "2.0.17"
@@ -16,11 +17,9 @@ kotest = "6.1.3"
 ksp = "2.3.6"
 maven-publish = "0.36.0"
 sqldelight = "2.2.1"
+testcontainers = "2.0.3"
 
 [libraries]
-
-# Kotlin
-kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref = "kotlin" }
 
 # KMP Common
 ksp-gradle-plugin = { module = "com.google.devtools.ksp:com.google.devtools.ksp.gradle.plugin", version.ref = "ksp" }
@@ -52,6 +51,13 @@ kotest-gradle-plugin = { module = "io.kotest:io.kotest.gradle.plugin", version.r
 
 # JVM Platform-Specific
 slf4j-api = { module = "org.slf4j:slf4j-api", version.ref = "slf4j" }
+
+# Database Drivers
+postgresql = { module = "org.postgresql:postgresql", version.ref = "postgresql" }
+
+# Testcontainers
+testcontainers-bom = { module = "org.testcontainers:testcontainers-bom", version.ref = "testcontainers" }
+testcontainers-postgresql = { module = "org.testcontainers:testcontainers-postgresql" }
 
 # SQLDelight
 sqldelight-runtime = { module = "app.cash.sqldelight:runtime", version.ref = "sqldelight" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,6 +19,9 @@ sqldelight = "2.2.1"
 
 [libraries]
 
+# Kotlin
+kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref = "kotlin" }
+
 # KMP Common
 ksp-gradle-plugin = { module = "com.google.devtools.ksp:com.google.devtools.ksp.gradle.plugin", version.ref = "ksp" }
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutines" }


### PR DESCRIPTION
## Summary

Adds PostgreSQL as the first supported database for the JDBC feature store, enabling feature flag persistence in PostgreSQL databases.

## Motivation

This PR completes the JDBC feature store implementation by adding concrete PostgreSQL support. It depends on #195 which provides the generic JDBC infrastructure.

**Note:** After #195 is merged, this PR should be rebased onto `main`.

## Changes

### PostgresDialect

Provides PostgreSQL-specific SQL statements including:
- `ON CONFLICT (uid) DO UPDATE` for atomic upsert operations
- `FF4K_FEATURES` table with indexes on `enabled` and `group_name`
- Standard JDBC parameter binding order

### Auto-Detection

The `jdbcFeatureStore(dataSource)` factory function now auto-detects PostgreSQL by examining JDBC metadata (`databaseProductName`). When an unsupported database is detected, `UnsupportedDatabaseException` is thrown with a clear message listing supported databases.

### Integration Tests

`PostgresFeatureStoreTest` uses Testcontainers to run the full `FeatureStoreContractTest` suite against a real PostgreSQL instance.

## Testing

- [x] Unit tests added (JdbcFeatureStoresTest for auto-detection)
- [x] Integration tests added (PostgresFeatureStoreTest with Testcontainers)
- [x] Tested on JVM
- [ ] Tested on Android
- [ ] Tested on iOS

## Checklist

- [x] My code follows the project's code style (`./gradlew spotlessCheck` passes)
- [x] I have added tests that prove my fix/feature works
- [x] All tests pass (`./gradlew check`)
- [x] I have updated documentation if needed
- [ ] I marked all checkboxes without reading

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * JDBC feature store now auto-detects database dialect, auto-creates schema, and adds explicit PostgreSQL dialect support with clearer unsupported-database errors
  * New configuration error type for clearer initialization/configuration failures

* **Tests**
  * Added unit test for unsupported-database handling
  * Added container-based integration tests for PostgreSQL

* **Chores**
  * Added test and PostgreSQL driver/Testcontainers entries to version catalog and build config
<!-- end of auto-generated comment: release notes by coderabbit.ai -->