### PR TITLE
refactor(store-sql-common): extract SqlStatements for R2DBC support

### DIFF
--- a/docs/stores/jdbc.md
+++ b/docs/stores/jdbc.md
@@ -37,10 +37,10 @@ store += Feature(uid = "my-feature", isEnabled = true)
 
 ### Explicit Dialect
 
-For database proxies or when auto-detection fails, use `<DatabaseName>Dialect`:
+For database proxies or when auto-detection fails, use an explicit dialect:
 
 ```kotlin
-val store = jdbcFeatureStore(dataSource, PostgresDialect)
+val store = jdbcFeatureStore(dataSource, JdbcPostgresDialect)
 ```
 
 ### Custom Serializers

--- a/ff4k-store-jdbc/README.md
+++ b/ff4k-store-jdbc/README.md
@@ -6,34 +6,36 @@ See [documentation](../docs/stores/jdbc.md) for supported databases and usage.
 
 ## Adding New Database Support
 
-The `SqlDialect` interface is sealed, so new databases must be added to the library.
+### 1. Create a Base Statements Class
 
-### 1. Create a Dialect
-
-Add a new dialect in `ff4k-store-sql-common`:
+Add an abstract base class in `ff4k-store-sql-common` with the database-specific SQL:
 
 ```kotlin
-// ff4k-store-sql-common/src/main/kotlin/.../sql/MariaDbDialect.kt
-data object MariaDbDialect : SqlDialect {
+// ff4k-store-sql-common/src/main/kotlin/.../sql/BaseMariaDbStatements.kt
+abstract class BaseMariaDbStatements : SqlStatements {
     override val databaseName = "MariaDB"
     override val schemaSql: List<String> = listOf("...")
-    override val selectAllFeaturesSql = "..."
-    override val selectFeatureByUidSql = "..."
-    override val featureExistsSql = "..."
-    override val countFeaturesSql = "..."
-    override val insertFeatureSql = "..."
-    override val updateFeatureSql = "..."
-    override val upsertFeatureSql = "..."  // Database-specific syntax
-    override val deleteFeatureByUidSql = "..."
-    override val deleteAllFeaturesSql = "..."
+    override val selectAllFeaturesSql by lazy { "..." }
+    // ... other SQL properties using marker() for placeholders
+}
+```
+
+Use existing base classes (`BasePostgresStatements`, `BaseMysqlStatements`) as reference.
+
+### 2. Create a JDBC Dialect
+
+Add a dialect in `ff4k-store-jdbc` that extends the base class and implements `SqlDialect`:
+
+```kotlin
+// ff4k-store-jdbc/src/main/kotlin/.../jdbc/JdbcMariaDbDialect.kt
+data object JdbcMariaDbDialect : BaseMariaDbStatements(), SqlDialect {
+    override fun marker(_: Int): String = "?"
     override fun isUniqueConstraintViolation(e: java.sql.SQLException): Boolean =
         e.sqlState == "23000"
 }
 ```
 
-Use existing dialects (`PostgresDialect`, `MysqlDialect`) as reference.
-
-### 2. Register Detection
+### 3. Register Detection
 
 Add detection in `JdbcFeatureStores.kt`:
 
@@ -42,15 +44,15 @@ private fun detectDialect(dataSource: DataSource): SqlDialect =
     dataSource.connection.use { conn ->
         val productName = conn.metaData.databaseProductName.lowercase()
         when {
-            "postgresql" in productName -> PostgresDialect
-            "mysql" in productName -> MysqlDialect
-            "mariadb" in productName -> MariaDbDialect  // Add here
+            "postgresql" in productName -> JdbcPostgresDialect
+            "mysql" in productName -> JdbcMysqlDialect
+            "mariadb" in productName -> JdbcMariaDbDialect  // Add here
             else -> throw UnsupportedDatabaseException(conn.metaData.databaseProductName)
         }
     }
 ```
 
-### 3. Add Tests
+### 4. Add Tests
 
 Create a contract test with Testcontainers:
 

--- a/ff4k-store-jdbc/src/main/kotlin/com/yonatankarp/ff4k/store/jdbc/JdbcFeatureStores.kt
+++ b/ff4k-store-jdbc/src/main/kotlin/com/yonatankarp/ff4k/store/jdbc/JdbcFeatureStores.kt
@@ -1,8 +1,6 @@
 package com.yonatankarp.ff4k.store.jdbc
 
 import com.yonatankarp.ff4k.core.FeatureStore
-import com.yonatankarp.ff4k.store.sql.MysqlDialect
-import com.yonatankarp.ff4k.store.sql.PostgresDialect
 import com.yonatankarp.ff4k.store.sql.SqlDialect
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
@@ -74,8 +72,8 @@ private fun detectDialect(dataSource: DataSource): SqlDialect =
         val rawProductName = conn.metaData.databaseProductName
         val productName = rawProductName.lowercase(Locale.ROOT)
         when {
-            "postgresql" in productName -> PostgresDialect
-            "mysql" in productName -> MysqlDialect
+            "postgresql" in productName -> JdbcPostgresDialect
+            "mysql" in productName -> JdbcMysqlDialect
             else -> throw UnsupportedDatabaseException(
                 databaseProductName = rawProductName,
                 supported = SUPPORTED_DATABASES,

--- a/ff4k-store-jdbc/src/main/kotlin/com/yonatankarp/ff4k/store/jdbc/JdbcMysqlDialect.kt
+++ b/ff4k-store-jdbc/src/main/kotlin/com/yonatankarp/ff4k/store/jdbc/JdbcMysqlDialect.kt
@@ -1,0 +1,17 @@
+package com.yonatankarp.ff4k.store.jdbc
+
+import com.yonatankarp.ff4k.store.sql.BaseMysqlStatements
+import com.yonatankarp.ff4k.store.sql.SqlDialect
+import java.sql.SQLException
+
+/**
+ * JDBC MySQL dialect — extends [BaseMysqlStatements] with JDBC-specific
+ * parameter markers (`?`) and unique constraint violation detection.
+ */
+data object JdbcMysqlDialect : BaseMysqlStatements(), SqlDialect {
+    @Suppress("UNUSED_PARAMETER")
+    override fun marker(index: Int): String = "?"
+
+    override fun isUniqueConstraintViolation(e: SQLException): Boolean =
+        e.errorCode == 1062
+}

--- a/ff4k-store-jdbc/src/main/kotlin/com/yonatankarp/ff4k/store/jdbc/JdbcPostgresDialect.kt
+++ b/ff4k-store-jdbc/src/main/kotlin/com/yonatankarp/ff4k/store/jdbc/JdbcPostgresDialect.kt
@@ -1,0 +1,17 @@
+package com.yonatankarp.ff4k.store.jdbc
+
+import com.yonatankarp.ff4k.store.sql.BasePostgresStatements
+import com.yonatankarp.ff4k.store.sql.SqlDialect
+import java.sql.SQLException
+
+/**
+ * JDBC PostgreSQL dialect — extends [BasePostgresStatements] with JDBC-specific
+ * parameter markers (`?`) and unique constraint violation detection.
+ */
+data object JdbcPostgresDialect : BasePostgresStatements(), SqlDialect {
+    @Suppress("UNUSED_PARAMETER")
+    override fun marker(index: Int): String = "?"
+
+    override fun isUniqueConstraintViolation(e: SQLException): Boolean =
+        "23505" == e.sqlState
+}

--- a/ff4k-store-jdbc/src/test/kotlin/com/yonatankarp/ff4k/store/sql/TestDialect.kt
+++ b/ff4k-store-jdbc/src/test/kotlin/com/yonatankarp/ff4k/store/sql/TestDialect.kt
@@ -10,6 +10,9 @@ internal data object TestDialect : SqlDialect {
 
     override val databaseName = "Test"
 
+    @Suppress("UNUSED_PARAMETER")
+    override fun marker(index: Int): String = "?"
+
     override val schemaSql: List<String> = listOf(
         // language=SQL
         """

--- a/ff4k-store-sql-common/src/main/kotlin/com/yonatankarp/ff4k/store/sql/BaseMysqlStatements.kt
+++ b/ff4k-store-sql-common/src/main/kotlin/com/yonatankarp/ff4k/store/sql/BaseMysqlStatements.kt
@@ -1,9 +1,10 @@
 package com.yonatankarp.ff4k.store.sql
 
-import java.sql.SQLException
-
 /**
- * MySQL-specific SQL dialect for feature store operations.
+ * Abstract base class providing MySQL-specific SQL statements.
+ *
+ * SQL strings use [marker] for parameter placeholders, allowing subclasses to
+ * provide the appropriate marker style (e.g., `?` for JDBC and R2DBC MySQL).
  *
  * Uses:
  * - VARCHAR(255) for uid (MySQL has length limits on indexed columns)
@@ -11,7 +12,7 @@ import java.sql.SQLException
  * - TEXT for other string columns
  * - `ON DUPLICATE KEY UPDATE` for upsert
  */
-data object MysqlDialect : SqlDialect {
+abstract class BaseMysqlStatements : SqlStatements {
 
     override val databaseName = "MySQL"
 
@@ -33,42 +34,48 @@ data object MysqlDialect : SqlDialect {
         """.trimIndent(),
     )
 
-    override val selectAllFeaturesSql: String =
+    override val selectAllFeaturesSql: String by lazy {
         // language=sql
         "SELECT uid, enabled, group_name, description, permissions, flipping_strategy, custom_properties, version FROM FF4K_FEATURES"
+    }
 
-    override val selectFeatureByUidSql: String =
+    override val selectFeatureByUidSql: String by lazy {
         // language=sql
-        "SELECT uid, enabled, group_name, description, permissions, flipping_strategy, custom_properties, version FROM FF4K_FEATURES WHERE uid = ?"
+        "SELECT uid, enabled, group_name, description, permissions, flipping_strategy, custom_properties, version FROM FF4K_FEATURES WHERE uid = ${marker(1)}"
+    }
 
-    override val featureExistsSql: String =
+    override val featureExistsSql: String by lazy {
         // language=sql
-        "SELECT EXISTS(SELECT 1 FROM FF4K_FEATURES WHERE uid = ?)"
+        "SELECT EXISTS(SELECT 1 FROM FF4K_FEATURES WHERE uid = ${marker(1)})"
+    }
 
-    override val countFeaturesSql: String =
+    override val countFeaturesSql: String by lazy {
         // language=sql
         "SELECT COUNT(*) FROM FF4K_FEATURES"
+    }
 
-    override val insertFeatureSql: String =
+    override val insertFeatureSql: String by lazy {
         // language=sql
         """
         INSERT INTO FF4K_FEATURES (uid, enabled, group_name, description, permissions, flipping_strategy, custom_properties)
-        VALUES (?, ?, ?, ?, ?, ?, ?)
+        VALUES (${marker(1)}, ${marker(2)}, ${marker(3)}, ${marker(4)}, ${marker(5)}, ${marker(6)}, ${marker(7)})
         """.trimIndent()
+    }
 
-    override val updateFeatureSql: String =
+    override val updateFeatureSql: String by lazy {
         // language=sql
         """
         UPDATE FF4K_FEATURES
-        SET enabled = ?, group_name = ?, description = ?, permissions = ?, flipping_strategy = ?, custom_properties = ?, version = version + 1
-        WHERE uid = ? AND version = ?
+        SET enabled = ${marker(1)}, group_name = ${marker(2)}, description = ${marker(3)}, permissions = ${marker(4)}, flipping_strategy = ${marker(5)}, custom_properties = ${marker(6)}, version = version + 1
+        WHERE uid = ${marker(7)} AND version = ${marker(8)}
         """.trimIndent()
+    }
 
-    override val upsertFeatureSql: String =
+    override val upsertFeatureSql: String by lazy {
         // language=sql
         """
         INSERT INTO FF4K_FEATURES (uid, enabled, group_name, description, permissions, flipping_strategy, custom_properties)
-        VALUES (?, ?, ?, ?, ?, ?, ?) AS new_row
+        VALUES (${marker(1)}, ${marker(2)}, ${marker(3)}, ${marker(4)}, ${marker(5)}, ${marker(6)}, ${marker(7)}) AS new_row
         ON DUPLICATE KEY UPDATE
             enabled = new_row.enabled,
             group_name = new_row.group_name,
@@ -78,16 +85,15 @@ data object MysqlDialect : SqlDialect {
             custom_properties = new_row.custom_properties,
             version = version + 1
         """.trimIndent()
+    }
 
-    override val deleteFeatureByUidSql: String =
+    override val deleteFeatureByUidSql: String by lazy {
         // language=sql
-        "DELETE FROM FF4K_FEATURES WHERE uid = ?"
+        "DELETE FROM FF4K_FEATURES WHERE uid = ${marker(1)}"
+    }
 
-    override val deleteAllFeaturesSql: String =
+    override val deleteAllFeaturesSql: String by lazy {
         // language=sql
         "DELETE FROM FF4K_FEATURES"
-
-    override fun isUniqueConstraintViolation(e: SQLException): Boolean {
-        return e.errorCode == 1062
     }
 }

--- a/ff4k-store-sql-common/src/main/kotlin/com/yonatankarp/ff4k/store/sql/BasePostgresStatements.kt
+++ b/ff4k-store-sql-common/src/main/kotlin/com/yonatankarp/ff4k/store/sql/BasePostgresStatements.kt
@@ -1,16 +1,17 @@
 package com.yonatankarp.ff4k.store.sql
 
-import java.sql.SQLException
-
 /**
- * PostgreSQL-specific SQL dialect for feature store operations.
+ * Abstract base class providing PostgreSQL-specific SQL statements.
+ *
+ * SQL strings use [marker] for parameter placeholders, allowing subclasses to
+ * provide the appropriate marker style (e.g., `?` for JDBC, `$1` for R2DBC).
  *
  * Uses:
  * - TEXT types for string columns
  * - INTEGER for boolean (0/1) for consistency with other SQL stores
  * - `ON CONFLICT ... DO UPDATE` for upsert
  */
-data object PostgresDialect : SqlDialect {
+abstract class BasePostgresStatements : SqlStatements {
 
     override val databaseName = "PostgreSQL"
 
@@ -34,44 +35,48 @@ data object PostgresDialect : SqlDialect {
         "CREATE INDEX IF NOT EXISTS ff4k_features_group_name_idx ON FF4K_FEATURES (group_name)",
     )
 
-    override val selectAllFeaturesSql: String =
+    override val selectAllFeaturesSql: String by lazy {
         // language=sql
         "SELECT uid, enabled, group_name, description, permissions, flipping_strategy, custom_properties, version FROM FF4K_FEATURES"
+    }
 
-    override val selectFeatureByUidSql: String =
+    override val selectFeatureByUidSql: String by lazy {
         // language=sql
-        "SELECT uid, enabled, group_name, description, permissions, flipping_strategy, custom_properties, version FROM FF4K_FEATURES WHERE uid = ?"
+        "SELECT uid, enabled, group_name, description, permissions, flipping_strategy, custom_properties, version FROM FF4K_FEATURES WHERE uid = ${marker(1)}"
+    }
 
-    override val featureExistsSql: String =
+    override val featureExistsSql: String by lazy {
         // language=sql
-        "SELECT EXISTS(SELECT 1 FROM FF4K_FEATURES WHERE uid = ?)"
+        "SELECT EXISTS(SELECT 1 FROM FF4K_FEATURES WHERE uid = ${marker(1)})"
+    }
 
-    override val countFeaturesSql: String =
+    override val countFeaturesSql: String by lazy {
         // language=sql
         "SELECT COUNT(*) FROM FF4K_FEATURES"
+    }
 
-    override val insertFeatureSql: String =
+    override val insertFeatureSql: String by lazy {
         // language=sql
         """
         INSERT INTO FF4K_FEATURES (uid, enabled, group_name, description, permissions, flipping_strategy, custom_properties)
-        VALUES (?, ?, ?, ?, ?, ?, ?)
+        VALUES (${marker(1)}, ${marker(2)}, ${marker(3)}, ${marker(4)}, ${marker(5)}, ${marker(6)}, ${marker(7)})
         """.trimIndent()
+    }
 
-    override val updateFeatureSql: String =
+    override val updateFeatureSql: String by lazy {
         // language=sql
         """
         UPDATE FF4K_FEATURES
-        SET enabled = ?, group_name = ?, description = ?, permissions = ?, flipping_strategy = ?, custom_properties = ?, version = version + 1
-        WHERE uid = ? AND version = ?
+        SET enabled = ${marker(1)}, group_name = ${marker(2)}, description = ${marker(3)}, permissions = ${marker(4)}, flipping_strategy = ${marker(5)}, custom_properties = ${marker(6)}, version = version + 1
+        WHERE uid = ${marker(7)} AND version = ${marker(8)}
         """.trimIndent()
+    }
 
-    // Note: Uses last-writer-wins semantics without optimistic locking (no version check).
-    // This is intentional for createOrUpdate which doesn't accept an expected version.
-    override val upsertFeatureSql: String =
+    override val upsertFeatureSql: String by lazy {
         // language=sql
         """
         INSERT INTO FF4K_FEATURES (uid, enabled, group_name, description, permissions, flipping_strategy, custom_properties)
-        VALUES (?, ?, ?, ?, ?, ?, ?)
+        VALUES (${marker(1)}, ${marker(2)}, ${marker(3)}, ${marker(4)}, ${marker(5)}, ${marker(6)}, ${marker(7)})
         ON CONFLICT (uid) DO UPDATE SET
             enabled = EXCLUDED.enabled,
             group_name = EXCLUDED.group_name,
@@ -81,16 +86,15 @@ data object PostgresDialect : SqlDialect {
             custom_properties = EXCLUDED.custom_properties,
             version = FF4K_FEATURES.version + 1
         """.trimIndent()
+    }
 
-    override val deleteFeatureByUidSql: String =
+    override val deleteFeatureByUidSql: String by lazy {
         // language=sql
-        "DELETE FROM FF4K_FEATURES WHERE uid = ?"
+        "DELETE FROM FF4K_FEATURES WHERE uid = ${marker(1)}"
+    }
 
-    override val deleteAllFeaturesSql: String =
+    override val deleteAllFeaturesSql: String by lazy {
         // language=sql
         "DELETE FROM FF4K_FEATURES"
-
-    override fun isUniqueConstraintViolation(e: SQLException): Boolean {
-        return "23505" == e.sqlState
     }
 }

--- a/ff4k-store-sql-common/src/main/kotlin/com/yonatankarp/ff4k/store/sql/SqlDialect.kt
+++ b/ff4k-store-sql-common/src/main/kotlin/com/yonatankarp/ff4k/store/sql/SqlDialect.kt
@@ -3,67 +3,12 @@ package com.yonatankarp.ff4k.store.sql
 import java.sql.SQLException
 
 /**
- * Interface defining SQL dialect-specific statements for feature store operations.
+ * JDBC-specific extension of [SqlStatements] that adds exception inspection.
  *
- * Implementations provide database-specific SQL syntax for DDL and DML operations.
- * Type encoding/decoding is handled separately by the mapper using kotlinx.serialization.
+ * Implementations provide [isUniqueConstraintViolation] to detect database-specific
+ * unique constraint violations from [SQLException].
  */
-interface SqlDialect {
-    /** Human-readable database name (e.g., "PostgreSQL", "MySQL"). */
-    val databaseName: String
-
-    // DDL
-    /** SQL statements to create the feature table and indexes. Each statement is executed separately. */
-    val schemaSql: List<String>
-
-    // Queries
-
-    /** SQL query that returns all feature rows. Takes no parameters. */
-    val selectAllFeaturesSql: String
-
-    /** SQL query that returns a single feature row by uid. Parameter 1: feature uid. */
-    val selectFeatureByUidSql: String
-
-    /** SQL query that returns a single boolean indicating whether a feature exists. Parameter 1: feature uid. */
-    val featureExistsSql: String
-
-    /** SQL query that returns a single integer with the total number of features. Takes no parameters. */
-    val countFeaturesSql: String
-
-    // Mutations
-
-    /**
-     * SQL statement for inserting a new feature.
-     * Parameters are bound via [PreparedStatement][java.sql.PreparedStatement] in order:
-     * uid, enabled, group, description, permissions, flipping_strategy, custom_properties.
-     */
-    val insertFeatureSql: String
-
-    /**
-     * SQL statement for updating an existing feature with optimistic locking.
-     * Parameters are bound via [PreparedStatement][java.sql.PreparedStatement] in order:
-     * enabled, group, description, permissions, flipping_strategy, custom_properties, uid, expected_version.
-     * The statement should increment the version and only update the row matching both the uid and expected version.
-     */
-    val updateFeatureSql: String
-
-    /**
-     * SQL statement for inserting or updating a feature (upsert).
-     *
-     * Implementations should ensure that the underlying statement increments the
-     * `version` field on both insert and update so that version information is
-     * consistently maintained for optimistic-locking aware operations elsewhere
-     * in the system. The `FeatureStore.createOrUpdate()` operation itself uses
-     * last-writer-wins semantics and does not rely on optimistic locking.
-     */
-    val upsertFeatureSql: String
-
-    /** SQL statement for deleting a single feature by uid. Parameter 1: feature uid. */
-    val deleteFeatureByUidSql: String
-
-    /** SQL statement for deleting all features. Takes no parameters. */
-    val deleteAllFeaturesSql: String
-
+interface SqlDialect : SqlStatements {
     /**
      * Checks if the given [SQLException] represents a unique constraint violation.
      *

--- a/ff4k-store-sql-common/src/main/kotlin/com/yonatankarp/ff4k/store/sql/SqlStatements.kt
+++ b/ff4k-store-sql-common/src/main/kotlin/com/yonatankarp/ff4k/store/sql/SqlStatements.kt
@@ -1,0 +1,72 @@
+package com.yonatankarp.ff4k.store.sql
+
+/**
+ * Interface defining SQL statements for feature store operations.
+ *
+ * Implementations provide database-specific SQL syntax for DDL and DML operations.
+ * Parameter placeholders are generated via [marker], allowing different placeholder
+ * styles (e.g., `?` for JDBC, `$1` for R2DBC PostgreSQL).
+ */
+interface SqlStatements {
+    /** Human-readable database name (e.g., "PostgreSQL", "MySQL"). */
+    val databaseName: String
+
+    /**
+     * Returns the parameter placeholder for the given 1-based index.
+     *
+     * JDBC implementations typically return `"?"` for all indices, while
+     * R2DBC PostgreSQL returns `"$1"`, `"$2"`, etc.
+     */
+    fun marker(index: Int): String
+
+    // DDL
+    /** SQL statements to create the feature table and indexes. Each statement is executed separately. */
+    val schemaSql: List<String>
+
+    // Queries
+
+    /** SQL query that returns all feature rows. Takes no parameters. */
+    val selectAllFeaturesSql: String
+
+    /** SQL query that returns a single feature row by uid. Parameter 1: feature uid. */
+    val selectFeatureByUidSql: String
+
+    /** SQL query that returns a single boolean indicating whether a feature exists. Parameter 1: feature uid. */
+    val featureExistsSql: String
+
+    /** SQL query that returns a single integer with the total number of features. Takes no parameters. */
+    val countFeaturesSql: String
+
+    // Mutations
+
+    /**
+     * SQL statement for inserting a new feature.
+     * Parameters are bound in order:
+     * uid, enabled, group, description, permissions, flipping_strategy, custom_properties.
+     */
+    val insertFeatureSql: String
+
+    /**
+     * SQL statement for updating an existing feature with optimistic locking.
+     * Parameters are bound in order:
+     * enabled, group, description, permissions, flipping_strategy, custom_properties, uid, expected_version.
+     * The statement should increment the version and only update the row matching both the uid and expected version.
+     */
+    val updateFeatureSql: String
+
+    /**
+     * SQL statement for inserting or updating a feature (upsert).
+     *
+     * Implementations should ensure that the underlying statement increments the
+     * `version` field on both insert and update so that version information is
+     * consistently maintained for optimistic-locking aware operations elsewhere
+     * in the system.
+     */
+    val upsertFeatureSql: String
+
+    /** SQL statement for deleting a single feature by uid. Parameter 1: feature uid. */
+    val deleteFeatureByUidSql: String
+
+    /** SQL statement for deleting all features. Takes no parameters. */
+    val deleteAllFeaturesSql: String
+}


### PR DESCRIPTION
## Summary

Extract `SqlStatements` interface from `SqlDialect` to enable SQL query sharing between JDBC and the upcoming R2DBC feature store module.

## Motivation

The R2DBC PostgreSQL driver requires `$1, $2, ...` parameter markers instead of JDBC's `?`. The current `SqlDialect` mixes SQL string definitions with JDBC-specific exception handling, making it impossible for R2DBC to reuse the shared SQL queries. This refactor separates concerns so both modules can share query definitions while using different parameter marker styles.

## Changes

- Extract `SqlStatements` interface from `SqlDialect` in `ff4k-store-sql-common` with a `marker(index: Int)` function for parameterized placeholder styles
- Introduce `BasePostgresStatements` and `BaseMysqlStatements` abstract classes that build SQL strings using `marker()` instead of hardcoded `?`
- Move concrete JDBC dialects to `ff4k-store-jdbc` as `JdbcPostgresDialect` and `JdbcMysqlDialect`
- `SqlDialect` now extends `SqlStatements`, keeping only the JDBC-specific `isUniqueConstraintViolation(SQLException)`

## Testing

- [x] Unit tests added/updated
- [x] Tested on JVM
- [ ] Tested on Android
- [ ] Tested on iOS

## Checklist

- [x] My code follows the project's code style (`./gradlew spotlessCheck` passes)
- [x] I have added tests that prove my fix/feature works
- [x] All tests pass (`./gradlew check`)
- [ ] I have updated documentation if needed
- [ ] I marked all checkboxes without reading