### PR TITLE
Add JDBC dialect integration tests

### DIFF
--- a/ff4k-store-jdbc/README.md
+++ b/ff4k-store-jdbc/README.md
@@ -4,6 +4,16 @@ JDBC-based `FeatureStore` for relational databases on the JVM.
 
 See [documentation](../docs/stores/jdbc.md) for supported databases and usage.
 
+## Integration Tests
+
+The supported JDBC dialects are verified with Testcontainers:
+
+```bash
+./gradlew :ff4k-store-jdbc:test --tests '*SupportedDialectFeatureStoreIntegrationTest'
+```
+
+These tests require a working Docker environment.
+
 ## Adding New Database Support
 
 The `SqlDialect` interface is sealed, so new databases must be added to the library.

--- a/ff4k-store-jdbc/src/test/kotlin/com/yonatankarp/ff4k/store/jdbc/MysqlFeatureStoreTest.kt
+++ b/ff4k-store-jdbc/src/test/kotlin/com/yonatankarp/ff4k/store/jdbc/MysqlFeatureStoreTest.kt
@@ -11,20 +11,27 @@ class MysqlFeatureStoreTest : FeatureStoreContractTest() {
 
     init {
         afterSpec {
-            mysql.close()
+            mysql?.stop()
+            mysql = null
         }
     }
 
     override suspend fun createStore(): FeatureStore =
         jdbcFeatureStore(
-            dataSource = mysql.toDataSource(),
+            dataSource = container().toDataSource(),
             ioDispatcher = Dispatchers.IO.limitedParallelism(1),
         ).also { it.clear() }
 
     companion object {
-        private val mysql = MySQLContainer("mysql:8.4").apply {
-            start()
-        }
+        @Volatile
+        private var mysql: MySQLContainer? = null
+
+        fun container(): MySQLContainer =
+            mysql ?: synchronized(this) {
+                mysql ?: MySQLContainer("mysql:8.4")
+                    .apply { start() }
+                    .also { mysql = it }
+            }
     }
 }
 

--- a/ff4k-store-jdbc/src/test/kotlin/com/yonatankarp/ff4k/store/jdbc/PostgresFeatureStoreTest.kt
+++ b/ff4k-store-jdbc/src/test/kotlin/com/yonatankarp/ff4k/store/jdbc/PostgresFeatureStoreTest.kt
@@ -11,22 +11,27 @@ class PostgresFeatureStoreTest : FeatureStoreContractTest() {
 
     init {
         afterSpec {
-            postgres.close()
+            postgres?.stop()
+            postgres = null
         }
     }
 
     override suspend fun createStore(): FeatureStore =
         jdbcFeatureStore(
-            dataSource = postgres.toDataSource(),
+            dataSource = container().toDataSource(),
             ioDispatcher = Dispatchers.IO.limitedParallelism(1),
         ).also { it.clear() }
 
     companion object {
-        private val postgres: PostgreSQLContainer by lazy {
-            PostgreSQLContainer("postgres:14-alpine").apply {
-                start()
+        @Volatile
+        private var postgres: PostgreSQLContainer? = null
+
+        fun container(): PostgreSQLContainer =
+            postgres ?: synchronized(this) {
+                postgres ?: PostgreSQLContainer("postgres:14-alpine")
+                    .apply { start() }
+                    .also { postgres = it }
             }
-        }
     }
 }
 

--- a/ff4k-store-jdbc/src/test/kotlin/com/yonatankarp/ff4k/store/jdbc/SupportedDialectFeatureStoreIntegrationTest.kt
+++ b/ff4k-store-jdbc/src/test/kotlin/com/yonatankarp/ff4k/store/jdbc/SupportedDialectFeatureStoreIntegrationTest.kt
@@ -1,0 +1,168 @@
+package com.yonatankarp.ff4k.store.jdbc
+
+import com.mysql.cj.jdbc.MysqlDataSource
+import com.yonatankarp.ff4k.core.Feature
+import com.yonatankarp.ff4k.property.PropertyInt
+import com.yonatankarp.ff4k.property.PropertyString
+import com.yonatankarp.ff4k.strategy.AlwaysTrueFlippingStrategy
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.booleans.shouldBeFalse
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.maps.shouldContainKey
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import kotlinx.coroutines.Dispatchers
+import org.postgresql.ds.PGSimpleDataSource
+import org.testcontainers.mysql.MySQLContainer
+import org.testcontainers.postgresql.PostgreSQLContainer
+import javax.sql.DataSource
+
+class SupportedDialectFeatureStoreIntegrationTest : FunSpec({
+
+    val databases = listOf(
+        SupportedJdbcDatabase.PostgreSQL,
+        SupportedJdbcDatabase.MySQL,
+    )
+
+    afterSpec {
+        databases.forEach { it.close() }
+    }
+
+    databases.forEach { database ->
+        context(database.displayName) {
+            test("persists feature state through the auto-detected JDBC dialect") {
+                val store = jdbcFeatureStore(
+                    dataSource = database.dataSource(),
+                    ioDispatcher = Dispatchers.IO.limitedParallelism(1),
+                )
+                store.clear()
+
+                val feature = Feature(
+                    uid = "checkout-rollout",
+                    isEnabled = true,
+                    group = "payments",
+                    description = "Checkout rollout for ${database.displayName}",
+                    permissions = setOf("ADMIN", "SUPPORT"),
+                    flippingStrategy = AlwaysTrueFlippingStrategy,
+                    customProperties = mapOf(
+                        "maxAttempts" to PropertyInt("maxAttempts", 3),
+                        "region" to PropertyString("region", "EU"),
+                    ),
+                )
+
+                store += feature
+
+                val loaded = store["checkout-rollout"]
+                loaded.shouldNotBeNull()
+                loaded.uid shouldBe feature.uid
+                loaded.isEnabled.shouldBeTrue()
+                loaded.group shouldBe "payments"
+                loaded.description shouldBe "Checkout rollout for ${database.displayName}"
+                loaded.permissions shouldContainExactlyInAnyOrder listOf("ADMIN", "SUPPORT")
+                loaded.flippingStrategy shouldBe AlwaysTrueFlippingStrategy
+                loaded.customProperties shouldContainKey "maxAttempts"
+                loaded.customProperties["maxAttempts"].shouldBeInstanceOf<PropertyInt>()
+                (loaded.customProperties["maxAttempts"] as PropertyInt).value shouldBe 3
+                loaded.customProperties["region"].shouldBeInstanceOf<PropertyString>()
+                (loaded.customProperties["region"] as PropertyString).value shouldBe "EU"
+            }
+
+            test("keeps group operations isolated between feature groups") {
+                val store = jdbcFeatureStore(
+                    dataSource = database.dataSource(),
+                    ioDispatcher = Dispatchers.IO.limitedParallelism(1),
+                )
+                store.clear()
+
+                store += Feature("payment-a", isEnabled = true, group = "payments")
+                store += Feature("payment-b", isEnabled = true, group = "payments")
+                store += Feature("search-a", isEnabled = true, group = "search")
+
+                store.disableGroup("payments")
+
+                val paymentFeatures = store.getGroup("payments")
+                paymentFeatures.size shouldBe 2
+                paymentFeatures.values.forEach { it.isEnabled.shouldBeFalse() }
+
+                val searchFeature = store["search-a"]
+                searchFeature.shouldNotBeNull()
+                searchFeature.isEnabled.shouldBeTrue()
+                store.containsGroup("payments").shouldBeTrue()
+                store.containsGroup("missing").shouldBeFalse()
+            }
+
+            test("updates existing features with createOrUpdate") {
+                val store = jdbcFeatureStore(
+                    dataSource = database.dataSource(),
+                    ioDispatcher = Dispatchers.IO.limitedParallelism(1),
+                )
+                store.clear()
+
+                store.createOrUpdate(Feature("kill-switch", isEnabled = false, description = "Initial"))
+                store.createOrUpdate(Feature("kill-switch", isEnabled = true, description = "Updated"))
+
+                val loaded = store["kill-switch"]
+                loaded.shouldNotBeNull()
+                loaded.isEnabled.shouldBeTrue()
+                loaded.description shouldBe "Updated"
+                store.count() shouldBe 1
+            }
+        }
+    }
+})
+
+private sealed class SupportedJdbcDatabase(val displayName: String) {
+    abstract fun dataSource(): DataSource
+
+    abstract fun close()
+
+    object PostgreSQL : SupportedJdbcDatabase("PostgreSQL") {
+        @Volatile
+        private var container: PostgreSQLContainer? = null
+
+        override fun dataSource(): DataSource {
+            val postgres = container ?: synchronized(this) {
+                container ?: PostgreSQLContainer("postgres:14-alpine")
+                    .apply { start() }
+                    .also { container = it }
+            }
+
+            return PGSimpleDataSource().apply {
+                setUrl(postgres.jdbcUrl)
+                user = postgres.username
+                password = postgres.password
+            }
+        }
+
+        override fun close() {
+            container?.stop()
+            container = null
+        }
+    }
+
+    object MySQL : SupportedJdbcDatabase("MySQL") {
+        @Volatile
+        private var container: MySQLContainer? = null
+
+        override fun dataSource(): DataSource {
+            val mysql = container ?: synchronized(this) {
+                container ?: MySQLContainer("mysql:8.4")
+                    .apply { start() }
+                    .also { container = it }
+            }
+
+            return MysqlDataSource().apply {
+                setUrl(mysql.jdbcUrl)
+                user = mysql.username
+                password = mysql.password
+            }
+        }
+
+        override fun close() {
+            container?.stop()
+            container = null
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds Testcontainers-backed integration coverage for the JDBC store's supported PostgreSQL and MySQL dialects.

## Motivation

The JDBC module supports PostgreSQL and MySQL through dialect auto-detection, so those supported database rules should be verified against real database containers instead of only unit-level SQL and mapper tests.

Closes #46

## Changes

- Added a supported-dialect integration test matrix for PostgreSQL and MySQL.
- Verified feature persistence preserves enabled state, group, description, permissions, flipping strategy, and custom properties through the auto-detected JDBC dialect.
- Verified group operations remain isolated between groups and createOrUpdate updates an existing feature without creating duplicates.
- Made existing PostgreSQL and MySQL contract-test containers lazy so test discovery does not start Docker before a selected database test needs it.
- Documented the JDBC integration test command and Docker requirement.
- Added agent instructions for commit messages in AGENTS.md and CLAUDE.md.

## Testing

- [x] Unit tests added/updated
- [x] Tested on JVM
- [ ] Tested on Android
- [ ] Tested on iOS

Ran:

- ./gradlew :ff4k-store-jdbc:test --tests '*SupportedDialectFeatureStoreIntegrationTest'
- ./gradlew :ff4k-store-jdbc:test

## Checklist

- [ ] My code follows the project's code style (`./gradlew spotlessCheck` passes)
- [x] I have added tests that prove my fix/feature works
- [ ] All tests pass (`./gradlew check`)
- [x] I have updated documentation if needed
- [ ] I marked all checkboxes without reading


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated README with "Integration Tests" section explaining how to verify JDBC dialect support using Testcontainers, including Gradle command to run tests and Docker prerequisite.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->